### PR TITLE
Fix incorrect expansion of SGE/SGEU instructions

### DIFF
--- a/mips.yaml
+++ b/mips.yaml
@@ -1073,7 +1073,7 @@ pseudoinstructions:
       format: [Rd, Rs, Rt]
     expand:
       - inst: SLT
-        data: [$Rd, $Rt, $Rs]
+        data: [$Rd, $Rs, $Rt]
       - inst: ORI
         data: [$At, $0, 1]
       - inst: SUB
@@ -1102,7 +1102,7 @@ pseudoinstructions:
       format: [Rd, Rs, Rt]
     expand:
       - inst: SLTU
-        data: [$Rd, $Rt, $Rs]
+        data: [$Rd, $Rs, $Rt]
       - inst: ORI
         data: [$At, $0, 1]
       - inst: SUB


### PR DESCRIPTION
Fixes issue with incorrect results with `sge` reported on COMP1521 course forum: https://discourse.cse.unsw.edu.au/21t3/comp1521/t/difference-in-sge-between-spim-and-mipsy/2158

Test program:
```
li      $t0, 3
sge     $t1, $t0, 10
````

Expected value in `$t1`: 0
Actual value in `$t1`: 1
