### PR TITLE
Correctly expand tabs when showing errors

### DIFF
--- a/crates/mipsy_lib/src/error/compiler/mod.rs
+++ b/crates/mipsy_lib/src/error/compiler/mod.rs
@@ -70,13 +70,13 @@ impl CompilerError {
         let updated_line = {
             let mut updated_line = String::new();
             
-            for (idx, char) in line.char_indices() {
+            for char in line.chars() {
                 if char != '\t' {
                     updated_line.push(char);
                     continue;
                 }
 
-                let spaces_to_insert = config.tab_size - (idx as u32 % config.tab_size);
+                let spaces_to_insert = config.tab_size - (updated_line.len() as u32 % config.tab_size);
                 updated_line.push_str(&" ".repeat(spaces_to_insert as usize));
             }
 

--- a/crates/mipsy_lib/src/error/parser/mod.rs
+++ b/crates/mipsy_lib/src/error/parser/mod.rs
@@ -65,13 +65,13 @@ impl ParserError {
         let updated_line = {
             let mut updated_line = String::new();
 
-            for (idx, char) in line.char_indices() {
+            for char in line.chars() {
                 if char != '\t' {
                     updated_line.push(char);
                     continue;
                 }
 
-                let spaces_to_insert = config.tab_size - (idx as u32 % config.tab_size);
+                let spaces_to_insert = config.tab_size - (updated_line.len() as u32 % config.tab_size);
                 updated_line.push_str(&" ".repeat(spaces_to_insert as usize));
             }
 


### PR DESCRIPTION
Previously the char index of the original line was being used to
determine how many spaces tabs should expand to. This assumption breaks
when multiple tabs are in the same line, so the char index of the
updated line is now used.
This fixes the fatal error mentioned in #124 for parsing errors, and improves the error reporting for compiler errors.

previous parsing error behaviour:
```
$ cat -A tab.s                                                                         1 ↵
main:$
x^I^I,$
m:$
$ mipsy tab.s
error: failed to parse `tab.s`
thread 'main' panicked at 'attempt to subtract with overflow', crates/mipsy_lib/src/error/parse
r/mod.rs:120:21
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

new parsing error behaviour:
```
$ mipsy tab.s
error: failed to parse `tab.s`
 --> ./tab.s:2:17
  |
2 | x               ,
  |                 ^ failed to parse
```

previous compiler error behaviour:
```
$ cat -A tab.s                                                                         1 ↵
main:$
li x^I^I, 0$
m:$
$ mipsy tab.s 
error: failed to compile `tab.s`
 --> ./tab.s:2:1
  |
2 | li x       , 0
  | ^^^^^^^^^^^^^^^^^^^ instruction `li` exists but was given incorrect arguments
tip: valid formats for `li`:
  - li $Rs, i16
  - li $Rs, u16
  - li $Rs, i32
  - li $Rs, u32
```

new compiler error behaviour:
```
$ mipsy tab.s
error: failed to compile `tab.s`
 --> ./tab.s:2:1
  |
2 | li x            , 0
  | ^^^^^^^^^^^^^^^^^^^ instruction `li` exists but was given incorrect arguments
tip: valid formats for `li`:
  - li $Rs, i16
  - li $Rs, u16
  - li $Rs, i32
  - li $Rs, u32
```