### PR TITLE
Prevent infinitely looping when encountering an error in the last line of a program

### DIFF
--- a/test_files/runtime_error/only_add.s
+++ b/test_files/runtime_error/only_add.s
@@ -8,10 +8,10 @@ main:
 
 	.data
 words:
-	.word 0 1 2 3 4
+	.word 0, 1, 2, 3, 4
 
 bytes:
-	.byte 5 6 7 8 9
+	.byte 5, 6, 7, 8, 9
 
 hello:
 	.asciiz "Hello"


### PR DESCRIPTION
`try_find_pseudo_expansion_end()` was infinitely looping if the last line was a multi-line pseudoinstruction and had an error e.g. used an uninitialised register, since the address of the next instruction couldn't be determined.
Since I'm not aware of a way to easily get the number of pseudoinstructions, the function now returns DATA_BOT and the loops using this value break once valid instructions are no longer found.

example offending file:
```
$ cat loop.s
main:
        sub $t0, $t1, 1
```

note: line 324 doesn't have this check on the return value since it's searching for a previous instruction that uninitialised a register, which by definition can't be the last instruction in a program. This is true even for multi-file MIPS programs where the offending instruction may have been at the end of one of the files.