### PR TITLE
add more informative errors if read_int syscall will overflow

### DIFF
--- a/crates/mipsy/src/main.rs
+++ b/crates/mipsy/src/main.rs
@@ -105,11 +105,11 @@ where
 
 fn get_input_int(name: &str) -> Option<i32> {
     loop {
-        let result: Result<i64, _> = try_read!();
+        let result: Result<i128, _> = try_read!();
 
         match result {
             Ok(n) => {
-                if n < std::i32::MIN as i64 || n > std::i32::MAX as i64 {
+                if n < std::i32::MIN as i128 || n > std::i32::MAX as i128 {
                     println!("[mipsy] bad input (too big to fit in 32 bits)");
                     println!("[mipsy] if you want the value to be truncated to 32 bits, try {}", n as i32);
                     print!(  "[mipsy] try again: ");

--- a/crates/mipsy/src/main.rs
+++ b/crates/mipsy/src/main.rs
@@ -108,7 +108,17 @@ fn get_input_int(name: &str) -> Option<i32> {
         let result: Result<i64, _> = try_read!();
 
         match result {
-            Ok(n) => return Some(n as i32),
+            Ok(n) => {
+                if n < std::i32::MIN as i64 || n > std::i32::MAX as i64 {
+                    println!("[mipsy] bad input (too big to fit in 32 bits)");
+                    println!("[mipsy] if you want the value to be truncated to 32 bits, try {}", n as i32);
+                    print!(  "[mipsy] try again: ");
+                    std::io::stdout().flush().unwrap();
+                    continue;
+                }
+
+                return Some(n as i32)
+            },
             Err(text_io::Error::Parse(leftover, _)) => {
                 if leftover == "" {
                     return None;

--- a/crates/mipsy_interactive/src/interactive/runtime_handler.rs
+++ b/crates/mipsy_interactive/src/interactive/runtime_handler.rs
@@ -91,11 +91,11 @@ fn get_input_int(name: &str, verbose: bool) -> Option<i32> {
         };
 
     loop {
-        let result: Result<i64, _> = try_read!();
+        let result: Result<i128, _> = try_read!();
 
         match result {
             Ok(n) => {
-                if n < std::i32::MIN as i64 || n > std::i32::MAX as i64 {
+                if n < std::i32::MIN as i128 || n > std::i32::MAX as i128 {
                     (too_big_prompt)();
                     println!("[mipsy] if you want the value to be truncated to 32 bits, try {}", n as i32);
                     print!(  "[mipsy] try again: ");


### PR DESCRIPTION
fixes #33

if the number can't fit into 128 bits, then the error message reverts to the old "bad input (expected int), try again: ", but 128 bits is a high enough ceiling that it probably isn't worth trying to distinguish those cases from regular parse errors.