### PR TITLE
Invert tab shading

### DIFF
--- a/crates/mipsy_web/src/components/outputarea.rs
+++ b/crates/mipsy_web/src/components/outputarea.rs
@@ -31,15 +31,15 @@ pub fn render_output_area(props: &OutputProps) -> Html {
         None => "".to_string(),
     };
 
-    let (mipsy_tab_button_classes, io_tab_classes) = {
+    let (io_tab_classes, mipsy_output_tab_classes) = {
         let default_tab_classes = "w-1/2 float-left border-t-2 border-r-2 border-black cursor-pointer px-1 py-2";
         let left_tab_classes = format!("{} border-l-2", default_tab_classes);
         let selected_classes = "bg-th-primary";
         let unselected_classes = "bg-th-tabunselected hover:bg-th-tabhover";
 
         (
-            format!("{} {}", default_tab_classes, if *props.show_io {unselected_classes} else {selected_classes}),
             format!("{} {}", left_tab_classes,  if *props.show_io {selected_classes} else {unselected_classes}),
+            format!("{} {}", default_tab_classes, if *props.show_io {unselected_classes} else {selected_classes}),
         )
     };
 
@@ -72,7 +72,7 @@ pub fn render_output_area(props: &OutputProps) -> Html {
             <div style="height: 10%;" class="flex overflow-hidden border-1 border-black">
                 <button class={io_tab_classes} onclick={switch_to_io.clone()}>{"I/O"}</button>
                 <button
-                    class={mipsy_tab_button_classes}
+                    class={mipsy_output_tab_classes}
                     onclick={switch_to_errors.clone()}
                 >
                     {props.mipsy_output_tab_title.clone()}

--- a/crates/mipsy_web/src/components/outputarea.rs
+++ b/crates/mipsy_web/src/components/outputarea.rs
@@ -37,17 +37,10 @@ pub fn render_output_area(props: &OutputProps) -> Html {
         let selected_classes = "bg-th-primary";
         let unselected_classes = "bg-th-tabunselected hover:bg-th-tabhover";
 
-        if *props.show_io {
-            (
-                format!("{} {}", default_tab_classes, unselected_classes),
-                format!("{} {}", left_tab_classes, selected_classes),
-            )
-        } else {
-            (
-                format!("{} {}", default_tab_classes, selected_classes),
-                format!("{} {}", left_tab_classes, unselected_classes),
-            )
-        }
+        (
+            format!("{} {}", default_tab_classes, if *props.show_io {unselected_classes} else {selected_classes}),
+            format!("{} {}", left_tab_classes,  if *props.show_io {selected_classes} else {unselected_classes}),
+        )
     };
 
     let input_classes = if !syscall_input_needed {

--- a/crates/mipsy_web/src/components/outputarea.rs
+++ b/crates/mipsy_web/src/components/outputarea.rs
@@ -32,18 +32,22 @@ pub fn render_output_area(props: &OutputProps) -> Html {
     };
 
     let (mipsy_tab_button_classes, io_tab_classes) = {
-        let mut default = (
-						    String::from("w-1/2 hover:bg-white float-left border-t-2 border-r-2 border-black cursor-pointer px-1 py-2"),
-						    String::from("w-1/2 hover:bg-white float-left border-t-2 border-r-2 border-l-2 border-black cursor-pointer px-1 py-2")
-					  );
+        let default_tab_classes = "w-1/2 float-left border-t-2 border-r-2 border-black cursor-pointer px-1 py-2";
+        let left_tab_classes = format!("{} border-l-2", default_tab_classes);
+        let selected_classes = "bg-th-primary";
+        let unselected_classes = "bg-th-tabunselected hover:bg-th-tabhover";
 
         if *props.show_io {
-            default.1 = format!("{} {}", &default.1, String::from("bg-th-tabclicked"));
+            (
+                format!("{} {}", default_tab_classes, unselected_classes),
+                format!("{} {}", left_tab_classes, selected_classes),
+            )
         } else {
-            default.0 = format!("{} {}", &default.0, String::from("bg-th-tabclicked"));
-        };
-
-        default
+            (
+                format!("{} {}", default_tab_classes, selected_classes),
+                format!("{} {}", left_tab_classes, unselected_classes),
+            )
+        }
     };
 
     let input_classes = if !syscall_input_needed {
@@ -88,7 +92,7 @@ pub fn render_output_area(props: &OutputProps) -> Html {
                 <div class="w-full overflow-y-auto">
                 <h1>
                     <strong>
-                        {if *props.show_io {"Output"} else {"Mipsy Output"}}
+                        {if *props.show_io {"I/O"} else {"Mipsy Output"}}
                     </strong>
                 </h1>
                 <pre style="width:100%;" class="text-sm whitespace-pre-wrap">

--- a/crates/mipsy_web/src/pages/main/app.rs
+++ b/crates/mipsy_web/src/pages/main/app.rs
@@ -369,27 +369,36 @@ pub fn render_app() -> Html {
     };
 
     let (decompiled_tab_classes, source_tab_classes, data_tab_classes) = {
-        let mut default = (
-            String::from("w-1/2 leading-none hover:bg-white float-left border-t-2 border-r-2 border-black cursor-pointer px-1"),
-            String::from("w-1/2 leading-none hover:bg-white float-left border-t-2 border-r-2 border-l-2 border-black cursor-pointer px-1 "),
-            String::from("w-1/2 leading-none hover:bg-white float-left border-t-2 border-r-2 border-black cursor-pointer px-1 ")
-        );
+        let default_tab_classes = "w-1/2 leading-none float-left border-t-2 border-r-2 border-black cursor-pointer px-1";
+        let left_tab_classes = format!("{} border-l-2", default_tab_classes);
+        let selected_classes = "bg-th-primary";
+        let unselected_classes = "bg-th-tabunselected hover:bg-th-tabhover";
 
         match *show_tab {
             DisplayedTab::Source => {
-                default.1 = format!("{} {}", &default.1, String::from("bg-th-tabclicked"));
+                (
+                    format!("{} {}", default_tab_classes, unselected_classes), 
+                    format!("{} {}", left_tab_classes, selected_classes),
+                    format!("{} {}", default_tab_classes, unselected_classes)
+                )
             }
 
             DisplayedTab::Decompiled => {
-                default.0 = format!("{} {}", &default.0, String::from("bg-th-tabclicked"));
+                (
+                    format!("{} {}", default_tab_classes, selected_classes), 
+                    format!("{} {}", left_tab_classes, unselected_classes),
+                    format!("{} {}", default_tab_classes, unselected_classes)
+                )
             }
 
             DisplayedTab::Data => {
-                default.2 = format!("{} {}", &default.2, String::from("bg-th-tabclicked"));
+                (
+                    format!("{} {}", default_tab_classes, unselected_classes), 
+                    format!("{} {}", left_tab_classes, unselected_classes),
+                    format!("{} {}", default_tab_classes, selected_classes)
+                )
             }
-        };
-
-        default
+        }
     };
 
     let input_needed = match &*state {

--- a/crates/mipsy_web/src/pages/main/app.rs
+++ b/crates/mipsy_web/src/pages/main/app.rs
@@ -368,7 +368,7 @@ pub fn render_app() -> Html {
         }
     };
 
-    let (decompiled_tab_classes, source_tab_classes, data_tab_classes) = {
+    let (source_tab_classes, decompiled_tab_classes, data_tab_classes) = {
         let default_tab_classes = "w-1/2 leading-none float-left border-t-2 border-r-2 border-black cursor-pointer px-1";
         let left_tab_classes = format!("{} border-l-2", default_tab_classes);
         let selected_classes = "bg-th-primary";
@@ -377,24 +377,24 @@ pub fn render_app() -> Html {
         match *show_tab {
             DisplayedTab::Source => {
                 (
-                    format!("{} {}", default_tab_classes, unselected_classes), 
                     format!("{} {}", left_tab_classes, selected_classes),
+                    format!("{} {}", default_tab_classes, unselected_classes), 
                     format!("{} {}", default_tab_classes, unselected_classes)
                 )
             }
 
             DisplayedTab::Decompiled => {
                 (
-                    format!("{} {}", default_tab_classes, selected_classes), 
                     format!("{} {}", left_tab_classes, unselected_classes),
+                    format!("{} {}", default_tab_classes, selected_classes), 
                     format!("{} {}", default_tab_classes, unselected_classes)
                 )
             }
 
             DisplayedTab::Data => {
                 (
-                    format!("{} {}", default_tab_classes, unselected_classes), 
                     format!("{} {}", left_tab_classes, unselected_classes),
+                    format!("{} {}", default_tab_classes, unselected_classes), 
                     format!("{} {}", default_tab_classes, selected_classes)
                 )
             }

--- a/crates/mipsy_web/tailwind.config.js
+++ b/crates/mipsy_web/tailwind.config.js
@@ -20,8 +20,10 @@ module.exports = {
                 'th-secondary': '#f0f0f0',
                 // used for step highlighting
                 'th-highlighting':'#34d399',
-                // selected tab
-                'th-tabclicked': '#d19292',
+                // tab hover color
+                'th-tabhover': '#fff0f0',
+                // unselected tab
+                'th-tabunselected': '#d19292',
             }
         }
     },


### PR DESCRIPTION
Makes the selected tab clearer by:
- using the appropriate heading for the i/o tab
- use a lighter color for the active tab, and darker shading for inactive tabs, as is common for most tabbed interfaces
