### PR TITLE
allow breakpoints to have associated commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,18 +956,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.116"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.116"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/mipsy_interactive/Cargo.toml
+++ b/crates/mipsy_interactive/Cargo.toml
@@ -10,9 +10,9 @@ path = "src/lib.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mipsy_lib = { version = "0.1.0", path = "../mipsy_lib" }
-mipsy_parser = { version = "0.1.0", path = "../mipsy_parser" }
-mipsy_utils = { version = "0.1.0", path = "../mipsy_utils" }
+mipsy_lib          = { version = "0.1.0", path = "../mipsy_lib" }
+mipsy_parser       = { version = "0.1.0", path = "../mipsy_parser" }
+mipsy_utils        = { version = "0.1.0", path = "../mipsy_utils" }
 mipsy_instructions = { path = "../mipsy_instructions", features = ["rt_yaml"] }
 serde = { version = "1.0", features = ["derive"] }  # for data deserialization
 serde_yaml = "0.8"                                  #   - see ~/.config/mipsy/config.yaml

--- a/crates/mipsy_interactive/src/interactive/commands/back.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/back.rs
@@ -28,7 +28,7 @@ pub(crate) fn back_command() -> Command {
             let times = match args.first() {
                 Some(arg) => expect_u32(
                     label,
-                    &"[times]".bright_magenta().to_string(),
+                    &"[times]".bright_magenta(),
                     arg, 
                     Some(|neg: i32|
                         format!("try `{}{}`", "step ".bold(), (-neg).to_string().bold())

--- a/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
@@ -1,4 +1,4 @@
-use crate::interactive::{error::CommandError, prompt, InteractiveBreakpoint, InteractiveCommand};
+use crate::interactive::{error::CommandError, prompt, InteractiveBreakpoint};
 use std::iter::successors;
 
 use super::*;
@@ -169,12 +169,7 @@ fn breakpoint_insert(state: &mut State, label: &str, mut args: &[String], remove
         id = binary.generate_breakpoint_id();
         let mut bp = InteractiveBreakpoint::new(id);
         if temporary {
-            bp.commands.push(InteractiveCommand {
-                command: breakpoint_command(),
-                label: "breakpoint",
-                // TODO(joshh): bother cleaning up args when command is deleted
-                args: Box::leak(Box::new(["remove".to_string(), format!("!{id}")])),
-            });
+            bp.commands.push(format!("breakpoint remove !{id}"))
         }
         state.breakpoints.insert(addr, bp);
 

--- a/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
@@ -52,8 +52,10 @@ pub(crate) fn breakpoint_command() -> Command {
                     breakpoint_toggle(state, label,  args, BpState::Disable),
                 "t" | "toggle" =>
                     breakpoint_toggle(state, label,  args, BpState::Toggle),
-                 _ =>
+                _ if label != "__help__" =>
                     breakpoint_insert(state, label,  args, false),
+                _ =>
+                    Ok(get_long_help()),
             }
         }
     )
@@ -100,7 +102,7 @@ fn breakpoint_insert(state: &mut State, label: &str, mut args: &[String], remove
                  When running or stepping through your program, a breakpoint will cause execution to\n\
                  pause temporarily, allowing you to debug the current state.\n\
                  May error if provided a label that doesn't exist.\n\
-                 If temporary is provided as the second argument, the breakpoint will be created as a\n\
+                 If {13} is provided as the second argument, the breakpoint will be created as a\n\
                  temporary breakpoint, which automatically deletes itself after being hit.
               \n{7}{8} you can also use the `{9}` MIPS instruction in your program's code!",
                 "<insert>".magenta(),
@@ -114,8 +116,9 @@ fn breakpoint_insert(state: &mut State, label: &str, mut args: &[String], remove
                 ":".bold(),
                 "break".bold(),
                 "breakpoint".yellow().bold(),
-                "{insert, delete}".purple(),
+                "{insert, delete, temporary}".purple(),
                 "temporary?".purple(),
+                "temporary".purple(),
             )
         )
     }

--- a/crates/mipsy_interactive/src/interactive/commands/commands.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/commands.rs
@@ -11,7 +11,7 @@ pub(crate) fn commands_command() -> Command {
         "commands",
         vec![],
         vec![],
-        vec!["breakpoint id"],
+        vec!["list", "breakpoint id"],
         "attach commands to a breakpoint",
         |state, label, mut args| {
             let get_error = |expected: &str, instead: &str| generate_err(
@@ -23,14 +23,17 @@ pub(crate) fn commands_command() -> Command {
                 return Ok(
                     format!(
                         "Takes in a list of commands seperated by newlines,\n\
-                         and attaches the commands to the specified {}.\n\
+                         and attaches the commands to the specified {0}.\n\
                          If no breakpoint is specified, the most recently created breakpoint is chosen.\n\
                          Whenever that breakpoint is hit, the commands will automatically be executed\n\
                          in the provided order.\n\
-                         The list of commands can be ended using the {} command, EOF, or an empty line.
+                         The list of commands can be ended using the {1} command, EOF, or an empty line.\n\
+                         To view the commands attached to a particular breakpoint,\n\
+                         use {2} {0}
                         ",
-                        "[breakpoint id]".purple(),
+                        "<breakpoint id>".purple(),
                         "end".yellow().bold(),
+                        "commands list".bold().yellow(),
                     )
                 )
             }

--- a/crates/mipsy_interactive/src/interactive/commands/commands.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/commands.rs
@@ -1,0 +1,92 @@
+use colored::Colorize;
+use rustyline::error::ReadlineError;
+
+use crate::{interactive::{editor, error::CommandError}, prompt};
+
+use super::*;
+
+pub(crate) fn commands_command() -> Command {
+    command(
+        "commands",
+        vec![],
+        vec![],
+        vec!["breakpoint id"],
+        "attach commands to a breakpoint",
+        |state, label, args| {
+            let get_error = |expected: &str, instead: &str| generate_err(
+                CommandError::BadArgument { arg: expected.magenta().to_string(), instead: instead.into() },
+                &String::from(""),
+            );
+
+            if label == "__help__" {
+                return Ok(
+                    "TODO: commands help".into()
+                    // make sure to talk about optional specification
+                    // and make the end syntax clear
+                )
+            }
+
+            // TODO: give instructions
+            // TODO: decide on behavious when commands already exist
+            // println!("{} ")
+
+            let id: u32 = if args.is_empty() {
+                state.breakpoints.values()
+                    .map(|bp| bp.breakpoint.id)
+                    .fold(u32::MIN, |x, y| x.max(y))
+            } else if let Some(id) = args[0].strip_prefix('!') {
+                id.parse().map_err(|_| get_error("<id>", &args[0]))?
+            } else {
+                return Err(get_error("<id>", &args[0]))
+            };
+
+            let commands;
+            if let Some(br) = state.breakpoints.iter_mut().find(|bp| bp.1.breakpoint.id == id) {
+                commands = &mut br.1.commands;
+            } else {
+                prompt::error_nl(format!(
+                    "breakpoint at {} doesn't exist",
+                    format!("!{id}").blue(),
+                ));
+                return Ok("".into());
+            }
+
+            let mut rl = editor();
+            loop {
+                let readline = rl.readline("");
+
+                match readline {
+                    Ok(line) => {
+                        if line.is_empty() || line == "\n" || line == "end" {
+                            state.confirm_exit = true;
+                            break;
+                        }
+
+                        commands.push(line);
+                    }
+                    Err(ReadlineError::Interrupted) => {}
+                    Err(ReadlineError::Eof) => {
+                        std::process::exit(0);
+                    }
+                    Err(err) => {
+                        println!("Error: {:?}", err);
+                        break;
+                    }
+                }
+            }
+
+            Ok("".into())
+        }
+    )
+}
+
+fn generate_err(error: CommandError, command_name: impl Into<String>) -> CommandError {
+    let mut help = String::from("help breakpoint");
+    let command_name = command_name.into();
+    if !command_name.is_empty() { help.push(' ') };
+
+    CommandError::WithTip {
+        error: Box::new(error),
+        tip: format!("try `{}{}`", help.bold(), command_name.bold()),
+    } 
+}

--- a/crates/mipsy_interactive/src/interactive/commands/commands.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/commands.rs
@@ -9,7 +9,7 @@ use super::*;
 pub(crate) fn commands_command() -> Command {
     command(
         "commands",
-        vec![],
+        vec!["com", "comms", "cmd", "cmds", "command"],
         vec![],
         vec!["list", "breakpoint id"],
         "attach commands to a breakpoint",

--- a/crates/mipsy_interactive/src/interactive/commands/commands.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/commands.rs
@@ -21,9 +21,17 @@ pub(crate) fn commands_command() -> Command {
 
             if label == "__help__" {
                 return Ok(
-                    "TODO: commands help".into()
-                    // make sure to talk about optional specification
-                    // and make the end syntax clear
+                    format!(
+                        "Takes in a list of commands seperated by newlines,\n\
+                         and attaches the commands to the specified {}.\n\
+                         If no breakpoint is specified, the most recently created breakpoint is chosen.\n\
+                         Whenever that breakpoint is hit, the commands will automatically be executed\n\
+                         in the provided order.\n\
+                         The list of commands can be ended using the {} command, EOF, or an empty line.
+                        ",
+                        "[breakpoint id]".purple(),
+                        "end".yellow().bold(),
+                    )
                 )
             }
 

--- a/crates/mipsy_interactive/src/interactive/commands/context.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/context.rs
@@ -31,7 +31,7 @@ pub(crate) fn context_command() -> Command {
             let n = match args.first() {
                 Some(arg) => expect_u32(
                     label,
-                    &"[n]".bright_magenta().to_string(),
+                    &"[n]".bright_magenta(),
                     arg,
                     f
                 ),

--- a/crates/mipsy_interactive/src/interactive/commands/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/mod.rs
@@ -1,6 +1,7 @@
 mod back;
 mod breakpoint;
 mod context;
+mod commands;
 mod disassemble;
 mod dot;
 mod exit;
@@ -19,6 +20,7 @@ pub(crate) mod util;
 pub(crate) use back::back_command;
 pub(crate) use breakpoint::breakpoint_command;
 pub(crate) use context::context_command;
+pub(crate) use commands::commands_command;
 pub(crate) use disassemble::disassemble_command;
 pub(crate) use dot::dot_command;
 pub(crate) use exit::exit_command;

--- a/crates/mipsy_interactive/src/interactive/commands/step.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/step.rs
@@ -28,7 +28,7 @@ pub(crate) fn step_command() -> Command {
             let times = match args.first() {
                 Some(arg) => expect_u32(
                     label,
-                    &"[times]".bright_magenta().to_string(),
+                    &"[times]".bright_magenta(),
                     arg, 
                     Some(|neg: i32|
                         format!("try `{}{}`", "back ".bold(), (-neg).to_string().bold())

--- a/crates/mipsy_interactive/src/interactive/helper.rs
+++ b/crates/mipsy_interactive/src/interactive/helper.rs
@@ -11,9 +11,7 @@ use rustyline::{
         FilenameCompleter, 
         Pair,
     },
-    highlight::{
-        Highlighter,
-    },
+    highlight::Highlighter,
     hint::{
         Hinter,
         HistoryHinter,
@@ -27,7 +25,7 @@ use rustyline::{
 use rustyline_derive::Helper;
 
 #[derive(Helper)]
-pub(super) struct MyHelper {
+pub(crate) struct MyHelper {
     completer: FilenameCompleter,
     hinter: HistoryHinter,
 }

--- a/crates/mipsy_interactive/src/interactive/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/mod.rs
@@ -543,7 +543,7 @@ impl State {
     }
 }
 
-fn editor() -> Editor<MyHelper> {
+pub(crate) fn editor() -> Editor<MyHelper> {
     let mut rl = Editor::new();
 
     let helper = MyHelper::new();
@@ -574,6 +574,7 @@ fn state(config: MipsyConfig) -> State {
     state.add_command(commands::dot_command());
     state.add_command(commands::help_command());
     state.add_command(commands::exit_command());
+    state.add_command(commands::commands_command());
 
     state
 }

--- a/crates/mipsy_interactive/src/interactive/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/mod.rs
@@ -4,6 +4,8 @@ mod helper;
 mod error;
 mod runtime_handler;
 
+use mipsy_lib::compile::Breakpoint;
+use std::collections::HashMap;
 use std::{ops::Deref, rc::Rc};
 
 use mipsy_lib::{MipsyError, ParserError, error::parser, runtime::{SteppedRuntime, state::TIMELINE_MAX_LEN}};
@@ -37,19 +39,42 @@ use mipsy_utils::MipsyConfig;
 
 use self::error::{CommandError, CommandResult};
 
-pub(crate) struct State {
+#[derive(Clone, Default)]
+pub(crate) struct InteractiveBreakpoint<'a> {
+    breakpoint: Breakpoint,
+    commands: Vec<InteractiveCommand<'a>>,
+}
+
+#[derive(Clone)]
+pub(crate) struct InteractiveCommand<'a> {
+    command: Command,
+    label: &'a str,
+    args: &'a [String],
+}
+
+impl InteractiveBreakpoint<'_> {
+    pub fn new(id: u32) -> Self {
+        Self {
+            breakpoint: Breakpoint::new(id),
+            commands: Vec::new(),
+        }
+    }
+}
+
+pub struct State<'a> {
     pub(crate) config: MipsyConfig,
     pub(crate) iset: InstSet,
     pub(crate) commands: Vec<Command>,
     pub(crate) program: Option<Vec<(String, String)>>,
     pub(crate) binary:  Option<Binary>,
+    pub(crate) breakpoints: HashMap<u32, InteractiveBreakpoint<'a>>,
     pub(crate) runtime: Option<Runtime>,
     pub(crate) exited: bool,
     pub(crate) prev_command: Option<String>,
     pub(crate) confirm_exit: bool,
 }
 
-impl State {
+impl State<'_> {
     fn new(config: MipsyConfig) -> Self {
         Self {
             config,
@@ -57,6 +82,7 @@ impl State {
             commands: vec![],
             program: None,
             binary:  None,
+            breakpoints: HashMap::new(),
             runtime: None,
             exited: false,
             prev_command: None,
@@ -456,13 +482,21 @@ impl State {
                 // if let Some(bp) = self.breakpoints.get(&pc) || breakpoint {
                 //     if !bp.enabled { trapped }
 
-                let bp = binary.breakpoints.get(&pc).cloned().unwrap_or_default();
-                if breakpoint || bp.enabled {
+                let bp = self.breakpoints.get(&pc).cloned().unwrap_or_default();
+                if breakpoint || bp.breakpoint.enabled {
                     let label = binary.labels.iter()
                             .find(|(_, &addr)| addr == pc)
                             .map(|(name, _)| name.yellow().bold().to_string());
-                    
+
                     runtime_handler::breakpoint(label.as_deref(), pc);
+                    bp.commands.iter().for_each(|command| {
+                        // TODO(joshh): check error handling is working
+                        let result = (command.command.exec)(self, command.label, command.args);
+                        match result {
+                            Ok(_)    => {}
+                            Err(err) => self.handle_error(err, true),
+                        }
+                    });
 
                     true
 
@@ -532,7 +566,7 @@ fn editor() -> Editor<MyHelper> {
     rl
 }
 
-fn state(config: MipsyConfig) -> State {
+fn state(config: MipsyConfig) -> State<'static> {
     let mut state = State::new(config);
 
     state.add_command(commands::load_command());

--- a/crates/mipsy_interactive/src/interactive/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/mod.rs
@@ -452,7 +452,7 @@ impl State {
                 let binary = self.binary.as_mut().unwrap();
                 let bp = binary.breakpoints.get_mut(&pc);
 
-                if breakpoint || bp.is_some() {
+                if breakpoint || (bp.is_some() && bp.as_ref().unwrap().enabled) {
                     if bp.is_some() && bp.as_ref().unwrap().ignore_count > 0 {
                         bp.unwrap().ignore_count -= 1;
                         trapped

--- a/crates/mipsy_lib/src/compile/mod.rs
+++ b/crates/mipsy_lib/src/compile/mod.rs
@@ -45,6 +45,7 @@ pub const KDATA_BOT:  u32 = 0x90000000;
 pub struct Breakpoint {
     pub id: u32,
     pub enabled: bool,
+    pub commands: Vec<String>,
 }
 
 impl Breakpoint {
@@ -52,6 +53,7 @@ impl Breakpoint {
         Self {
             id,
             enabled: true,
+            commands: Vec::new(),
         }
     }
 }

--- a/crates/mipsy_lib/src/compile/mod.rs
+++ b/crates/mipsy_lib/src/compile/mod.rs
@@ -46,6 +46,7 @@ pub struct Breakpoint {
     pub id: u32,
     pub enabled: bool,
     pub commands: Vec<String>,
+    pub ignore_count: u32,
 }
 
 impl Breakpoint {
@@ -54,6 +55,7 @@ impl Breakpoint {
             id,
             enabled: true,
             commands: Vec::new(),
+            ignore_count: 0,
         }
     }
 }

--- a/crates/mipsy_lib/src/compile/mod.rs
+++ b/crates/mipsy_lib/src/compile/mod.rs
@@ -56,7 +56,6 @@ impl Breakpoint {
     }
 }
 
-
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Binary {
     pub text:    Vec<Safe<u8>>,

--- a/crates/mipsy_web/src/worker.rs
+++ b/crates/mipsy_web/src/worker.rs
@@ -1,8 +1,7 @@
-use mipsy_lib::compile::Breakpoint;
 use crate::state::config::MipsyWebConfig;
 use crate::{state::state::MipsState, utils::decompile, utils::generate_highlighted_line};
 use log::{error, info};
-use mipsy_lib::compile::CompilerOptions;
+use mipsy_lib::compile::{Breakpoint, CompilerOptions};
 use mipsy_lib::error::runtime::ErrorContext;
 use mipsy_lib::{runtime::RuntimeSyscallGuard, Binary, InstSet, MipsyError, Runtime, Safe};
 use mipsy_parser::TaggedFile;


### PR DESCRIPTION
This also introduces the `breakpoint temporary` command, which creates a breakpoint that deletes itself after being hit
The ability to ignore breakpoints for a specified number of times has also been added
fixes #115 