### PR TITLE
allow run, step2input and step2syscall to be interrupted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b37feaa84e6861e00a1f5e5aa8da3ee56d605c9992d33e082786754828e20865"
+dependencies = [
+ "nix 0.24.2",
+ "winapi",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,6 +655,7 @@ name = "mipsy_interactive"
 version = "0.1.0"
 dependencies = [
  "colored",
+ "ctrlc",
  "dirs",
  "mipsy_instructions",
  "mipsy_lib",

--- a/crates/mipsy_interactive/Cargo.toml
+++ b/crates/mipsy_interactive/Cargo.toml
@@ -23,6 +23,7 @@ strip-ansi-escapes = "0.1"  # to strip color codes out for strlen calcs
 shlex = "0.1.0"             # 0.1.1 is latest, but I don't want # comments
 text_io = "0.1.8"           # to read values in, w/out per line
 dirs = "3.0"                # for user config directory
+ctrlc = { version = "3.0", features = ["termination"] } # for interrupt handling during execution
 
 [build-dependencies]
 vergen = "3"

--- a/crates/mipsy_interactive/src/interactive/commands/step.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/step.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::Ordering;
+
 use crate::interactive::error::CommandError;
 
 use super::*;
@@ -41,6 +43,7 @@ pub(crate) fn step_command() -> Command {
                 return Err(CommandError::ProgramExited);
             }
 
+            state.interrupted.store(false, Ordering::SeqCst);
             for _ in 0..times {
                 let binary  = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
                 let runtime = &state.runtime;
@@ -51,7 +54,7 @@ pub(crate) fn step_command() -> Command {
 
                 let step = state.step(true)?;
 
-                if step {
+                if step | state.interrupted.load(Ordering::SeqCst) {
                     break;
                 }
             }

--- a/crates/mipsy_interactive/src/interactive/commands/step2input.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/step2input.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::Ordering;
+
 use crate::interactive::error::CommandError;
 
 use super::*;
@@ -29,7 +31,8 @@ pub(crate) fn step2input_command() -> Command {
                 return Err(CommandError::ProgramExited);
             }
 
-            loop {
+            state.interrupted.store(false, Ordering::SeqCst);
+            while !state.interrupted.load(Ordering::SeqCst) {
                 let binary  = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
                 let runtime = &state.runtime;
 

--- a/crates/mipsy_interactive/src/interactive/commands/step2syscall.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/step2syscall.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::Ordering;
+
 use crate::interactive::error::CommandError;
 
 use super::*;
@@ -28,7 +30,8 @@ pub(crate) fn step2syscall_command() -> Command {
                 return Err(CommandError::ProgramExited);
             }
 
-            loop {
+            state.interrupted.store(false, Ordering::SeqCst);
+            while !state.interrupted.load(Ordering::SeqCst) {
                 let binary  = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
                 let runtime = &state.runtime;
 

--- a/crates/mipsy_interactive/src/interactive/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/mod.rs
@@ -4,7 +4,7 @@ mod helper;
 mod error;
 mod runtime_handler;
 
-use std::{mem::take, ops::Deref, rc::Rc};
+use std::{mem::take, ops::Deref, rc::Rc, sync::{atomic::{AtomicBool, Ordering}, Arc}};
 
 use mipsy_lib::{Binary, InstSet, Runtime, MipsyError, ParserError, error::parser, runtime::{SteppedRuntime, state::TIMELINE_MAX_LEN}};
 use mipsy_lib::runtime::{SYS13_OPEN, SYS14_READ, SYS15_WRITE, SYS16_CLOSE};
@@ -42,6 +42,7 @@ pub struct State {
     pub(crate) exited: bool,
     pub(crate) prev_command: Option<String>,
     pub(crate) confirm_exit: bool,
+    pub(crate) interrupted: Arc<AtomicBool>,
 }
 
 impl State {
@@ -56,6 +57,7 @@ impl State {
             exited: false,
             prev_command: None,
             confirm_exit: false,
+            interrupted: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -489,7 +491,8 @@ impl State {
             return Err(CommandError::ProgramExited);
         }
 
-        loop {
+        self.interrupted.store(false, Ordering::SeqCst);
+        while !self.interrupted.load(Ordering::SeqCst) {
             if self.step(false)? {
                 break;
             }
@@ -558,6 +561,8 @@ fn state(config: MipsyConfig) -> State {
 pub fn launch(config: MipsyConfig) -> ! {
     let mut rl = editor();
     let mut state = state(config);
+    let interrupted = state.interrupted.clone();
+    ctrlc::set_handler(move || interrupted.store(true, Ordering::SeqCst)).expect("Failed to set signal handler!");
 
     loop {
         let readline = rl.readline(state.prompt());


### PR DESCRIPTION
This is an admittedly simple implementation of interrupt handling during execution, but it appears to be effective.
Fixes #112