### PR TITLE
Make help consistent for subcommands

### DIFF
--- a/crates/mipsy_interactive/src/interactive/commands/back.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/back.rs
@@ -12,7 +12,7 @@ pub(crate) fn back_command() -> Command {
         vec!["times"],
         vec![],
         &format!("step backwards one (or {}) instruction", "[times]".magenta()),
-        |state, label, args| {
+        |_, state, label, args| {
             if label == "__help__" {
                 return Ok(
                     format!(

--- a/crates/mipsy_interactive/src/interactive/commands/back.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/back.rs
@@ -10,6 +10,7 @@ pub(crate) fn back_command() -> Command {
         vec!["b"],
         vec![],
         vec!["times"],
+        vec![],
         &format!("step backwards one (or {}) instruction", "[times]".magenta()),
         |state, label, args| {
             if label == "__help__" {

--- a/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
@@ -32,55 +32,55 @@ pub(crate) fn breakpoint_command() -> Command {
             "list", 
             vec!["l"],
             vec![], vec![], vec![], "",
-            |_, state, label, args| breakpoint_list(state, label, &args[1..])
+            |_, state, label, args| breakpoint_list(state, label, args)
         ),
         command(
             "insert", 
             vec!["i", "in", "ins", "add"],
             vec![], vec![], vec![], "",
-            |_, state, label, args| breakpoint_insert(state, label, &args[1..], InsertOp::Insert)
+            |_, state, label, args| breakpoint_insert(state, label, args, InsertOp::Insert)
         ),
         command(
             "remove", 
             vec!["del", "delete", "r", "rm"],
             vec![], vec![], vec![], "",
-            |_, state, label, args| breakpoint_insert(state, label, &args[1..], InsertOp::Delete)
+            |_, state, label, args| breakpoint_insert(state, label, args, InsertOp::Delete)
         ),
         command(
             "temporary", 
             vec!["tmp", "temp"],
             vec![], vec![], vec![], "",
-            |_, state, label, args| breakpoint_insert(state, label, &args[1..], InsertOp::Temporary)
+            |_, state, label, args| breakpoint_insert(state, label, args, InsertOp::Temporary)
         ),
         command(
             "enable", 
             vec!["e"],
             vec![], vec![], vec![], "",
-            |_, state, label, args| breakpoint_toggle(state, label, &args[1..], EnableOp::Enable)
+            |_, state, label, args| breakpoint_toggle(state, label, args, EnableOp::Enable)
         ),
         command(
             "disable", 
             vec!["d"],
             vec![], vec![], vec![], "",
-            |_, state, label, args| breakpoint_toggle(state, label, &args[1..], EnableOp::Disable)
+            |_, state, label, args| breakpoint_toggle(state, label, args, EnableOp::Disable)
         ),
         command(
             "toggle", 
             vec!["t"],
             vec![], vec![], vec![], "",
-            |_, state, label, args| breakpoint_toggle(state, label, &args[1..], EnableOp::Toggle)
+            |_, state, label, args| breakpoint_toggle(state, label, args, EnableOp::Toggle)
         ),
         command(
             "ignore", 
             vec![],
             vec![], vec![], vec![], "",
-            |_, state, label, args| breakpoint_ignore(state, label, &args[1..])
+            |_, state, label, args| breakpoint_ignore(state, label, args)
         ),
         command(
             "commands", 
             vec!["com", "comms", "cmd", "cmds", "command"],
             vec![], vec![], vec![], "",
-            |_, state, label, args| breakpoint_commands(state, label, &args[1..])
+            |_, state, label, args| breakpoint_commands(state, label, args)
         ),
     ];
 
@@ -104,7 +104,7 @@ pub(crate) fn breakpoint_command() -> Command {
             let cmd = cmd.subcommands.iter().find(|c| c.name == args[0] || c.aliases.contains(&args[0]));
             match cmd {
                 None if label == "__help__" => Ok(get_long_help()),
-                Some(cmd) => cmd.exec(state, label, args),
+                Some(cmd) => cmd.exec(state, label, &args[1..]),
                 None => breakpoint_insert(state, label, args, InsertOp::Insert),
             }
         }

--- a/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
@@ -27,7 +27,7 @@ enum MipsyArgType {
 }
 
 pub(crate) fn breakpoint_command() -> Command {
-    let subcommands: Vec<Command> = vec![
+    let subcommands = vec![
         command(
             "list", 
             vec!["l"],

--- a/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
@@ -29,55 +29,55 @@ enum MipsyArgType {
 pub(crate) fn breakpoint_command() -> Command {
     let subcommands = vec![
         command(
-            "list", 
+            "list",
             vec!["l"],
             vec![], vec![], vec![], "",
             |_, state, label, args| breakpoint_list(state, label, args)
         ),
         command(
-            "insert", 
+            "insert",
             vec!["i", "in", "ins", "add"],
             vec![], vec![], vec![], "",
             |_, state, label, args| breakpoint_insert(state, label, args, InsertOp::Insert)
         ),
         command(
-            "remove", 
+            "remove",
             vec!["del", "delete", "r", "rm"],
             vec![], vec![], vec![], "",
             |_, state, label, args| breakpoint_insert(state, label, args, InsertOp::Delete)
         ),
         command(
-            "temporary", 
+            "temporary",
             vec!["tmp", "temp"],
             vec![], vec![], vec![], "",
             |_, state, label, args| breakpoint_insert(state, label, args, InsertOp::Temporary)
         ),
         command(
-            "enable", 
+            "enable",
             vec!["e"],
             vec![], vec![], vec![], "",
             |_, state, label, args| breakpoint_toggle(state, label, args, EnableOp::Enable)
         ),
         command(
-            "disable", 
+            "disable",
             vec!["d"],
             vec![], vec![], vec![], "",
             |_, state, label, args| breakpoint_toggle(state, label, args, EnableOp::Disable)
         ),
         command(
-            "toggle", 
+            "toggle",
             vec!["t"],
             vec![], vec![], vec![], "",
             |_, state, label, args| breakpoint_toggle(state, label, args, EnableOp::Toggle)
         ),
         command(
-            "ignore", 
+            "ignore",
             vec![],
             vec![], vec![], vec![], "",
             |_, state, label, args| breakpoint_ignore(state, label, args)
         ),
         command(
-            "commands", 
+            "commands",
             vec!["com", "comms", "cmd", "cmds", "command"],
             vec![], vec![], vec![], "",
             |_, state, label, args| breakpoint_commands(state, label, args)

--- a/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
@@ -30,65 +30,56 @@ pub(crate) fn breakpoint_command() -> Command {
     let subcommands: Vec<Command> = vec![
         command(
             "list", 
-            vec!["l", "list"],
-            vec![], vec![], vec![],
-            "lists breakpoints", // TODO(joshh): make use of this in long help?
+            vec!["l"],
+            vec![], vec![], vec![], "",
             |_, state, label, args| breakpoint_list(state, label, &args[1..])
         ),
         command(
             "insert", 
-            vec!["i", "in", "ins", "insert", "add"],
-            vec![], vec![], vec![],
-            "inserts a breakpoint", // TODO(joshh): make use of this in long help?
+            vec!["i", "in", "ins", "add"],
+            vec![], vec![], vec![], "",
             |_, state, label, args| breakpoint_insert(state, label, &args[1..], InsertOp::Insert)
         ),
         command(
             "remove", 
-            vec!["del", "delete", "r", "rm", "remove"],
-            vec![], vec![], vec![],
-            "removes a breakpoint", // TODO(joshh): make use of this in long help?
+            vec!["del", "delete", "r", "rm"],
+            vec![], vec![], vec![], "",
             |_, state, label, args| breakpoint_insert(state, label, &args[1..], InsertOp::Delete)
         ),
         command(
             "temporary", 
-            vec!["tmp", "temp", "temporary"],
-            vec![], vec![], vec![],
-            "creates a temporary breakpoint", // TODO(joshh): make use of this in long help?
+            vec!["tmp", "temp"],
+            vec![], vec![], vec![], "",
             |_, state, label, args| breakpoint_insert(state, label, &args[1..], InsertOp::Temporary)
         ),
         command(
             "enable", 
-            vec!["e", "enable"],
-            vec![], vec![], vec![],
-            "enables a breakpoint", // TODO(joshh): make use of this in long help?
+            vec!["e"],
+            vec![], vec![], vec![], "",
             |_, state, label, args| breakpoint_toggle(state, label, &args[1..], EnableOp::Enable)
         ),
         command(
             "disable", 
-            vec!["d", "disable"],
-            vec![], vec![], vec![],
-            "disables a breakpoint", // TODO(joshh): make use of this in long help?
+            vec!["d"],
+            vec![], vec![], vec![], "",
             |_, state, label, args| breakpoint_toggle(state, label, &args[1..], EnableOp::Disable)
         ),
         command(
             "toggle", 
-            vec!["t", "toggle"],
-            vec![], vec![], vec![],
-            "toggles a breakpoint", // TODO(joshh): make use of this in long help?
+            vec!["t"],
+            vec![], vec![], vec![], "",
             |_, state, label, args| breakpoint_toggle(state, label, &args[1..], EnableOp::Toggle)
         ),
         command(
             "ignore", 
-            vec!["ignore"],
-            vec![], vec![], vec![],
-            "ignores a breakpoint", // TODO(joshh): make use of this in long help?
+            vec![],
+            vec![], vec![], vec![], "",
             |_, state, label, args| breakpoint_ignore(state, label, &args[1..])
         ),
         command(
             "commands", 
-            vec!["com", "comms", "cmd", "cmds", "command", "commands"],
-            vec![], vec![], vec![],
-            "adds commands to a breakpoint", // TODO(joshh): make use of this in long help?
+            vec!["com", "comms", "cmd", "cmds", "command"],
+            vec![], vec![], vec![], "",
             |_, state, label, args| breakpoint_commands(state, label, &args[1..])
         ),
     ];
@@ -110,7 +101,7 @@ pub(crate) fn breakpoint_command() -> Command {
                 )
             }
 
-            let cmd = cmd.subcommands.iter().find(|c| c.aliases.contains(&args[0]));
+            let cmd = cmd.subcommands.iter().find(|c| c.name == args[0] || c.aliases.contains(&args[0]));
             match cmd {
                 None if label == "__help__" => Ok(get_long_help()),
                 Some(cmd) => cmd.exec(state, label, args),

--- a/crates/mipsy_interactive/src/interactive/commands/commands.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/commands.rs
@@ -9,30 +9,30 @@ use crate::{interactive::{editor, error::CommandError}, prompt};
 use super::*;
 
 pub fn handle_commands<K, V: Point>(mut args: &[String], points: &mut HashMap<K, V>) -> Result<String, CommandError> {
-        let get_error = |expected: &str, instead: &str| generate_err(
-            CommandError::BadArgument { arg: expected.magenta().to_string(), instead: instead.into() },
-            &String::from(""),
-        );
+    let get_error = |expected: &str, instead: &str| generate_err(
+        CommandError::BadArgument { arg: expected.magenta().to_string(), instead: instead.into() },
+        &String::from(""),
+    );
 
-        let list = !args.is_empty() &&
-            matches!(args[0].as_ref(), "l" | "list");
-        if list { args = &args[1..]; }
+    let list = !args.is_empty() &&
+        matches!(args[0].as_ref(), "l" | "list");
+    if list { args = &args[1..]; }
 
-        let id: u32 = if args.is_empty() {
-            points.values()
-                .map(|bp| bp.get_id())
-                .fold(u32::MIN, |x, y| x.max(y))
-        } else if let Some(id) = args[0].strip_prefix('!') {
-            id.parse().map_err(|_| get_error("<id>", &args[0]))?
-        } else {
-            return Err(get_error("<id>", &args[0]))
-        };
+    let id: u32 = if args.is_empty() {
+        points.values()
+            .map(|bp| bp.get_id())
+            .fold(u32::MIN, |x, y| x.max(y))
+    } else if let Some(id) = args[0].strip_prefix('!') {
+        id.parse().map_err(|_| get_error("<id>", &args[0]))?
+    } else {
+        return Err(get_error("<id>", &args[0]))
+    };
 
-        if list {
-            list_commands(points, id)
-        } else {
-            add_commands(points, id)
-        }
+    if list {
+        list_commands(points, id)
+    } else {
+        add_commands(points, id)
+    }
 }
 
 fn add_commands<K, V: Point>(points: &mut HashMap<K, V>, id: u32) -> CommandResult<String> {

--- a/crates/mipsy_interactive/src/interactive/commands/context.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/context.rs
@@ -17,7 +17,7 @@ pub(crate) fn context_command() -> Command {
             "prints the current and surrounding 3 (or {}) instructions",
             "[n]".magenta(),
         ),
-        |state, label, args| {
+        |_, state, label, args| {
             if label == "__help__" {
                 return Ok(
                     format!(

--- a/crates/mipsy_interactive/src/interactive/commands/context.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/context.rs
@@ -12,6 +12,7 @@ pub(crate) fn context_command() -> Command {
         vec!["c", "ctx"],
         vec![],
         vec!["n"],
+        vec![],
         &format!(
             "prints the current and surrounding 3 (or {}) instructions",
             "[n]".magenta(),

--- a/crates/mipsy_interactive/src/interactive/commands/disassemble.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/disassemble.rs
@@ -11,6 +11,7 @@ pub(crate) fn disassemble_command() -> Command {
         vec!["d", "dis", "disasm", "dec", "decompile"],
         vec![],
         vec![],
+        vec![],
         "disassembles the currently loaded file",
         |state, label, _args| {
             if label == "__help__" {

--- a/crates/mipsy_interactive/src/interactive/commands/disassemble.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/disassemble.rs
@@ -13,7 +13,7 @@ pub(crate) fn disassemble_command() -> Command {
         vec![],
         vec![],
         "disassembles the currently loaded file",
-        |state, label, _args| {
+        |_, state, label, _args| {
             if label == "__help__" {
                 return Ok(
                     format!(

--- a/crates/mipsy_interactive/src/interactive/commands/dot.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/dot.rs
@@ -14,6 +14,7 @@ pub(crate) fn dot_command() -> Command {
         vec![],
         vec!["instruction"],
         "{args}",
+        vec![],
         "execute a MIPS instruction",
         |state, label, args| {
             if label == "__help__" {

--- a/crates/mipsy_interactive/src/interactive/commands/dot.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/dot.rs
@@ -16,7 +16,7 @@ pub(crate) fn dot_command() -> Command {
         "{args}",
         vec![],
         "execute a MIPS instruction",
-        |state, label, args| {
+        |_, state, label, args| {
             if label == "__help__" {
                 return Ok(
                     "Executes a MIPS instruction immediately".into()

--- a/crates/mipsy_interactive/src/interactive/commands/dot.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/dot.rs
@@ -1,3 +1,4 @@
+use colored::Colorize;
 use mipsy_lib::Binary;
 use std::rc::Rc;
 
@@ -13,7 +14,7 @@ pub(crate) fn dot_command() -> Command {
         ".",
         vec![],
         vec!["instruction"],
-        "{args}",
+        "{args}".magenta().to_string(),
         vec![],
         "execute a MIPS instruction",
         |_, state, label, args| {

--- a/crates/mipsy_interactive/src/interactive/commands/exit.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/exit.rs
@@ -9,7 +9,7 @@ pub(crate) fn exit_command() -> Command {
         vec![],
         vec![],
         "exit mipsy",
-        |_state, label, _args| {
+        |_, _state, label, _args| {
             if label == "__help__" {
                 return Ok(
                         "Immediately exits mipsy".into()

--- a/crates/mipsy_interactive/src/interactive/commands/exit.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/exit.rs
@@ -7,6 +7,7 @@ pub(crate) fn exit_command() -> Command {
         vec!["ex", "quit", "q"],
         vec![],
         vec![],
+        vec![],
         "exit mipsy",
         |_state, label, _args| {
             if label == "__help__" {

--- a/crates/mipsy_interactive/src/interactive/commands/help.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/help.rs
@@ -11,7 +11,7 @@ pub(crate) fn help_command() -> Command {
         vec!["command"],
         vec![],
         "print this help text, or specific help for a command",
-        |state, label, args| {
+        |_, state, label, args| {
             if label == "__help__" {
                 return Ok(
                     format!(
@@ -44,7 +44,7 @@ pub(crate) fn help_command() -> Command {
                 }
 
                 println!("\n{}\n", get_command_formatted(command, parts));
-                println!("{}", (command.exec)(state, "__help__", args).unwrap());
+                println!("{}", command.exec(state, "__help__", args).unwrap());
 
                 // TODO(joshh): get aliases of subcommand for subcommands e.g. `help breakpoint delete`?
                 if !command.aliases.is_empty() {

--- a/crates/mipsy_interactive/src/interactive/commands/help.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/help.rs
@@ -46,7 +46,6 @@ pub(crate) fn help_command() -> Command {
                 println!("\n{}\n", get_command_formatted(command, parts));
                 println!("{}", command.exec(state, "__help__", args).unwrap());
 
-                // TODO(joshh): get aliases of subcommand for subcommands e.g. `help breakpoint delete`?
                 if !command.aliases.is_empty() {
                     prompt::banner("\naliases".green().bold());
                     println!("{}", command.aliases.iter().map(|s| s.yellow().bold().to_string()).collect::<Vec<String>>().join(", "));

--- a/crates/mipsy_interactive/src/interactive/commands/help.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/help.rs
@@ -36,7 +36,7 @@ pub(crate) fn help_command() -> Command {
                 // TODO(joshh): include optional/required args for subcommands?
                 if !args.is_empty() {
                     let subcmd = command.subcommands.iter()
-                            .find(|c| c.aliases.contains(&args[0]));
+                            .find(|c| c.name == args[0] || c.aliases.contains(&args[0]));
                     if let Some(subcmd) = subcmd {
                         command = subcmd;
                         parts.push(command.name.yellow().bold().to_string());

--- a/crates/mipsy_interactive/src/interactive/commands/help.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/help.rs
@@ -97,7 +97,8 @@ pub(crate) fn help_command() -> Command {
                             "".magenta()       .to_string().len() * required.len() +
                             "".bright_magenta().to_string().len() * optional.len()
                         }
-                        Arguments::VarArgs { required: _, format: _ } => {
+                        Arguments::VarArgs { required, format: _ } => {
+                            "".magenta()       .to_string().len() * required.len() +
                             "".bright_magenta().to_string().len()
                         }
                     };

--- a/crates/mipsy_interactive/src/interactive/commands/label.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/label.rs
@@ -11,7 +11,7 @@ pub(crate) fn label_command() -> Command {
         vec![],
         vec![],
         "print the address of a label",
-        |state, label, args| {
+        |_, state, label, args| {
             if label == "__help__" {
                 return Ok(
                     format!(

--- a/crates/mipsy_interactive/src/interactive/commands/label.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/label.rs
@@ -9,6 +9,7 @@ pub(crate) fn label_command() -> Command {
         vec!["la", "lbl"],
         vec!["label"],
         vec![],
+        vec![],
         "print the address of a label",
         |state, label, args| {
             if label == "__help__" {

--- a/crates/mipsy_interactive/src/interactive/commands/labels.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/labels.rs
@@ -1,4 +1,4 @@
-use crate::interactive::{error::CommandError};
+use crate::interactive::error::CommandError;
 use mipsy_lib::DATA_BOT;
 
 use super::*;
@@ -8,6 +8,7 @@ pub(crate) fn labels_command() -> Command {
     command(
         "labels",
         vec!["ls", "las", "lbls"],
+        vec![],
         vec![],
         vec![],
         "prints the addresses of all labels",

--- a/crates/mipsy_interactive/src/interactive/commands/labels.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/labels.rs
@@ -12,7 +12,7 @@ pub(crate) fn labels_command() -> Command {
         vec![],
         vec![],
         "prints the addresses of all labels",
-        |state, label, _args| {
+        |_, state, label, _args| {
             if label == "__help__" {
                 return Ok(
                     "Prints the addresses of all labels in the currently loaded program.".into()

--- a/crates/mipsy_interactive/src/interactive/commands/load.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/load.rs
@@ -12,6 +12,7 @@ pub(crate) fn load_command() -> Command {
         vec!["l"],
         vec!["files"],
         "-- {args}".magenta().to_string(),
+        vec![],
         "load a MIPS file to run",
         |state, label, args| {
             if label == "__help__" {

--- a/crates/mipsy_interactive/src/interactive/commands/load.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/load.rs
@@ -14,7 +14,7 @@ pub(crate) fn load_command() -> Command {
         "-- {args}".magenta().to_string(),
         vec![],
         "load a MIPS file to run",
-        |state, label, args| {
+        |_, state, label, args| {
             if label == "__help__" {
                 return Ok(
                     format!(

--- a/crates/mipsy_interactive/src/interactive/commands/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/mod.rs
@@ -51,10 +51,9 @@ pub(crate) struct Command {
     pub(crate) name: String,
     pub(crate) aliases: Vec<String>,
     pub(crate) args: Arguments,
-    pub(crate) description: String,
-    pub(crate) _internal_exec: fn(&Command, &mut State, &str, &[String]) -> CommandResult<String>,
+    description: String,
+    _internal_exec: fn(&Command, &mut State, &str, &[String]) -> CommandResult<String>,
     subcommands: Vec<Command>,
-    // TODO(joshh): vec of Command for subcommands?
 }
 
 impl Command {

--- a/crates/mipsy_interactive/src/interactive/commands/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/mod.rs
@@ -53,9 +53,11 @@ pub(crate) struct Command {
     pub(crate) args: Arguments,
     pub(crate) description: String,
     pub(crate) exec: fn(&mut State, &str, &[String]) -> CommandResult<String>,
+    subcommands: Vec<Command>,
+    // TODO(joshh): vec of Command for subcommands?
 }
 
-pub(crate) fn command<S: Into<String>>(name: S, aliases: Vec<S>, required_args: Vec<S>, optional_args: Vec<S>, desc: S, exec: fn(&mut State, &str, &[String]) -> CommandResult<String>) -> Command {
+pub(crate) fn command<S: Into<String>>(name: S, aliases: Vec<S>, required_args: Vec<S>, optional_args: Vec<S>, subcommands: Vec<Command>, desc: S, exec: fn(&mut State, &str, &[String]) -> CommandResult<String>) -> Command {
     Command {
         name: name.into(),
         description: desc.into(),
@@ -65,15 +67,17 @@ pub(crate) fn command<S: Into<String>>(name: S, aliases: Vec<S>, required_args: 
             optional: optional_args.into_iter().map(S::into).collect(),
         },
         exec,
+        subcommands,
     }
 }
 
-pub(crate) fn command_varargs<S: Into<String>>(name: S, aliases: Vec<S>, required_args: Vec<S>, varargs_format: impl Into<String>, desc: S, exec: fn(&mut State, &str, &[String]) -> CommandResult<String>) -> Command {
+pub(crate) fn command_varargs<S: Into<String>>(name: S, aliases: Vec<S>, required_args: Vec<S>, varargs_format: impl Into<String>, subcommands: Vec<Command>, desc: S, exec: fn(&mut State, &str, &[String]) -> CommandResult<String>) -> Command {
     Command {
         name: name.into(),
         description: desc.into(),
         aliases: aliases.into_iter().map(S::into).collect(),
         args: Arguments::VarArgs { required: required_args.into_iter().map(S::into).collect(), format: varargs_format.into() },
         exec,
+        subcommands,
     }
 }

--- a/crates/mipsy_interactive/src/interactive/commands/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/mod.rs
@@ -52,12 +52,18 @@ pub(crate) struct Command {
     pub(crate) aliases: Vec<String>,
     pub(crate) args: Arguments,
     pub(crate) description: String,
-    pub(crate) exec: fn(&mut State, &str, &[String]) -> CommandResult<String>,
+    pub(crate) _internal_exec: fn(&Command, &mut State, &str, &[String]) -> CommandResult<String>,
     subcommands: Vec<Command>,
     // TODO(joshh): vec of Command for subcommands?
 }
 
-pub(crate) fn command<S: Into<String>>(name: S, aliases: Vec<S>, required_args: Vec<S>, optional_args: Vec<S>, subcommands: Vec<Command>, desc: S, exec: fn(&mut State, &str, &[String]) -> CommandResult<String>) -> Command {
+impl Command {
+    pub(crate) fn exec(&self, state: &mut State, label: &str, args: &[String]) -> CommandResult<String> {
+        (self._internal_exec)(self, state, label, args)
+    }
+}
+
+pub(crate) fn command<S: Into<String>>(name: S, aliases: Vec<S>, required_args: Vec<S>, optional_args: Vec<S>, subcommands: Vec<Command>, desc: S, exec: fn(&Command, &mut State, &str, &[String]) -> CommandResult<String>) -> Command {
     Command {
         name: name.into(),
         description: desc.into(),
@@ -66,18 +72,18 @@ pub(crate) fn command<S: Into<String>>(name: S, aliases: Vec<S>, required_args: 
             required: required_args.into_iter().map(S::into).collect(),
             optional: optional_args.into_iter().map(S::into).collect(),
         },
-        exec,
+        _internal_exec: exec,
         subcommands,
     }
 }
 
-pub(crate) fn command_varargs<S: Into<String>>(name: S, aliases: Vec<S>, required_args: Vec<S>, varargs_format: impl Into<String>, subcommands: Vec<Command>, desc: S, exec: fn(&mut State, &str, &[String]) -> CommandResult<String>) -> Command {
+pub(crate) fn command_varargs<S: Into<String>>(name: S, aliases: Vec<S>, required_args: Vec<S>, varargs_format: impl Into<String>, subcommands: Vec<Command>, desc: S, exec: fn(&Command, &mut State, &str, &[String]) -> CommandResult<String>) -> Command {
     Command {
         name: name.into(),
         description: desc.into(),
         aliases: aliases.into_iter().map(S::into).collect(),
         args: Arguments::VarArgs { required: required_args.into_iter().map(S::into).collect(), format: varargs_format.into() },
-        exec,
+        _internal_exec: exec,
         subcommands,
     }
 }

--- a/crates/mipsy_interactive/src/interactive/commands/print.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/print.rs
@@ -16,7 +16,7 @@ pub(crate) fn print_command() -> Command {
         vec!["format"],
         vec![],
         "print an item - a register, value in memory, etc.",
-        |state, label, args| {
+        |_, state, label, args| {
             if label == "__help__" {
                 return Ok(
                     format!(

--- a/crates/mipsy_interactive/src/interactive/commands/print.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/print.rs
@@ -14,6 +14,7 @@ pub(crate) fn print_command() -> Command {
         vec!["p"],
         vec!["item"],
         vec!["format"],
+        vec![],
         "print an item - a register, value in memory, etc.",
         |state, label, args| {
             if label == "__help__" {

--- a/crates/mipsy_interactive/src/interactive/commands/reset.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/reset.rs
@@ -11,7 +11,7 @@ pub(crate) fn reset_command() -> Command {
         vec![],
         vec![],
         "reset the currently loaded program to its initial state",
-        |state, label, _args| {
+        |_, state, label, _args| {
             if label == "__help__" {
                 return Ok(
                     format!(

--- a/crates/mipsy_interactive/src/interactive/commands/reset.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/reset.rs
@@ -9,6 +9,7 @@ pub(crate) fn reset_command() -> Command {
         vec!["re"],
         vec![],
         vec![],
+        vec![],
         "reset the currently loaded program to its initial state",
         |state, label, _args| {
             if label == "__help__" {

--- a/crates/mipsy_interactive/src/interactive/commands/run.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/run.rs
@@ -11,7 +11,7 @@ pub(crate) fn run_command() -> Command {
         vec![],
         vec![],
         "run the currently loaded program until it finishes",
-        |state, label, _args| {
+        |_, state, label, _args| {
             if label == "__help__" {
                 return Ok(
                     format!(

--- a/crates/mipsy_interactive/src/interactive/commands/run.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/run.rs
@@ -9,6 +9,7 @@ pub(crate) fn run_command() -> Command {
         vec!["r"],
         vec![],
         vec![],
+        vec![],
         "run the currently loaded program until it finishes",
         |state, label, _args| {
             if label == "__help__" {

--- a/crates/mipsy_interactive/src/interactive/commands/step.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/step.rs
@@ -14,7 +14,7 @@ pub(crate) fn step_command() -> Command {
         vec!["times"],
         vec![],
         &format!("step forwards one (or {}) instruction", "[times]".magenta()),
-        |state, label, args| {
+        |_, state, label, args| {
             if label == "__help__" {
                 return Ok(
                     format!(

--- a/crates/mipsy_interactive/src/interactive/commands/step.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/step.rs
@@ -12,6 +12,7 @@ pub(crate) fn step_command() -> Command {
         vec!["s"],
         vec![],
         vec!["times"],
+        vec![],
         &format!("step forwards one (or {}) instruction", "[times]".magenta()),
         |state, label, args| {
             if label == "__help__" {

--- a/crates/mipsy_interactive/src/interactive/commands/step2input.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/step2input.rs
@@ -15,7 +15,7 @@ pub(crate) fn step2input_command() -> Command {
         vec![],
         vec![],
         "step forwards until next input",
-        |state, label, _args| {
+        |_, state, label, _args| {
             if label == "__help__" {
                 return Ok(
                     format!(

--- a/crates/mipsy_interactive/src/interactive/commands/step2input.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/step2input.rs
@@ -13,6 +13,7 @@ pub(crate) fn step2input_command() -> Command {
         vec!["s2i"],
         vec![],
         vec![],
+        vec![],
         "step forwards until next input",
         |state, label, _args| {
             if label == "__help__" {

--- a/crates/mipsy_interactive/src/interactive/commands/step2syscall.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/step2syscall.rs
@@ -12,6 +12,7 @@ pub(crate) fn step2syscall_command() -> Command {
         vec!["s2s"],
         vec![],
         vec![],
+        vec![],
         "step forwards until next syscall",
         |state, label, _args| {
             if label == "__help__" {

--- a/crates/mipsy_interactive/src/interactive/commands/step2syscall.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/step2syscall.rs
@@ -14,7 +14,7 @@ pub(crate) fn step2syscall_command() -> Command {
         vec![],
         vec![],
         "step forwards until next syscall",
-        |state, label, _args| {
+        |_, state, label, _args| {
             if label == "__help__" {
                 return Ok(
                     format!(

--- a/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
@@ -30,7 +30,7 @@ pub(crate) fn watchpoint_command() -> Command {
             "manage watchpoints ({} to list subcommands)",
             "help watchpoint".bold()
         ),
-        |state, label, args| {
+        |_, state, label, args| {
             if label == "__help__" && args.is_empty() {
                 return Ok(
                     get_long_help()

--- a/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
@@ -25,6 +25,7 @@ pub(crate) fn watchpoint_command() -> Command {
         vec!["w", "wa", "wp", "watch"],
         vec!["subcommand"],
         vec![],
+        vec![],
         &format!(
             "manage watchpoints ({} to list subcommands)",
             "help watchpoint".bold()

--- a/crates/mipsy_interactive/src/interactive/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/mod.rs
@@ -111,7 +111,7 @@ impl State {
             None => return,
         };
 
-        let command = self.find_command(&command_name.to_ascii_lowercase());
+        let command = self.find_command(&command_name.to_ascii_lowercase()).cloned();
 
         if command.is_none() {
             prompt::unknown_command(command_name);
@@ -135,7 +135,7 @@ impl State {
             return;
         }
 
-        let result = (command.exec)(self, command_name, &parts[1..]);
+        let result = command.exec(self, command_name, &parts[1..]);
         match result {
             Ok(_)    => {}
             Err(err) => self.handle_error(err, true),


### PR DESCRIPTION
This allows subcommands to show aliases and proper names when displaying help and/or erroring on incorrect usage.