### PR TITLE
restore cursor position upon saving fix #262

### DIFF
--- a/crates/mipsy_web/index.html
+++ b/crates/mipsy_web/index.html
@@ -181,6 +181,13 @@
         html.style.color = color;
         html.style.borderColor = color;
       }
+
+      function get_cursor_position() {
+        return window.editor.getPosition();
+      }
+      function set_cursor_position(line, column) {
+        window.editor.setPosition({lineNumber: line, column: column});
+      }
     </script>
 
     <style id="mainCSS">

--- a/crates/mipsy_web/src/lib.rs
+++ b/crates/mipsy_web/src/lib.rs
@@ -35,6 +35,9 @@ extern "C" {
     pub fn update_editor_options(options: JsValue);
     pub fn update_editor_model_options(options: JsValue);
 
+    pub fn set_cursor_position(line: u32, column: u32);
+    pub fn get_cursor_position() -> JsValue;
+
     pub fn update_primary_color(color: &str);
     pub fn update_secondary_color(color: &str);
     pub fn update_tertiary_color(color: &str);

--- a/crates/mipsy_web/src/state/config.rs
+++ b/crates/mipsy_web/src/state/config.rs
@@ -1,10 +1,10 @@
 use std::rc::Rc;
 
 use bounce::prelude::*;
+use gloo_utils::format::JsValueSerdeExt;
 use mipsy_utils::MipsyConfig;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::JsValue;
-use gloo_utils::format::JsValueSerdeExt;
 
 // i should probably write a macro for this
 #[derive(Clone, PartialEq, Atom, Serialize, Deserialize)]
@@ -181,5 +181,22 @@ impl MipsyWebConfig {
             })
             .unwrap(),
         );
+    }
+}
+
+#[derive(Atom, Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MonacoCursor {
+    #[serde(rename = "lineNumber")]
+    pub line: u32,
+    pub column: u32,
+}
+
+impl From<JsValue> for MonacoCursor {
+    fn from(value: JsValue) -> Self {
+        let position = value.into_serde::<MonacoCursor>().unwrap();
+        MonacoCursor {
+            line: position.line,
+            column: position.column,
+        }
     }
 }

--- a/crates/mipsy_web/src/state/update.rs
+++ b/crates/mipsy_web/src/state/update.rs
@@ -2,14 +2,15 @@ use crate::{
     pages::main::app::{
         process_syscall_request, process_syscall_response, ReadSyscalls, NUM_INSTR_BEFORE_RESPONSE,
     },
-    state::state::{
+    state::{config::MonacoCursor, state::{
         DisplayedCodeTab, ErrorState, ErrorType, MipsState, RunningState, RuntimeErrorState, State,
-    },
+    }},
     worker::{
         FileInformation, ReadSyscallInputs, RuntimeErrorResponse, Worker, WorkerRequest,
         WorkerResponse,
     },
 };
+use bounce::prelude::UseAtomHandle;
 use gloo_console::log;
 use log::{error, info};
 use mipsy_lib::Safe;
@@ -30,6 +31,7 @@ pub fn handle_response_from_worker(
     worker: Rc<RefCell<Option<UseBridgeHandle<Worker>>>>,
     input_ref: UseStateHandle<NodeRef>,
     is_saved: UseStateHandle<bool>,
+    monaco_cursor: UseAtomHandle<MonacoCursor>,
 ) {
     match response {
         WorkerResponse::DecompiledCode(response_struct) => {
@@ -57,6 +59,7 @@ pub fn handle_response_from_worker(
                 crate::set_editor_value(&response_struct.file.clone().unwrap());
                 crate::set_localstorage_file_contents(&response_struct.file.unwrap());
                 is_saved.set(true);
+                crate::set_cursor_position(monaco_cursor.line, monaco_cursor.column);
             }
         }
 


### PR DESCRIPTION
In reality this is due to the fundamental flaw of us having to re-render the monaco editor upon each edit

(and, this is why you get flashes of syntax highlighting when you are typing a lot)

This is a workaround to save the cursor position upon save, and restore the cursor position if the 
save operation successfully returns a de compiled file. 


Note for v2: maybe use https://docs.rs/monaco/latest/monaco/ to avoid rendering problems