### PR TITLE
Fix SEQ instruction implementation

### DIFF
--- a/mips.yaml
+++ b/mips.yaml
@@ -1742,12 +1742,10 @@ pseudoinstructions:
     compile:
       format: [Rd, Rs, Rt]
     expand:
-      - inst: ORI
-        data: [$Rd, $0, 1]
-      - inst: BEQ
-        data: [$Rs, $Rt, 2]
-      - inst: ORI
-        data: [$Rd, $0, 0]
+      - inst: XOR
+        data: [$Rd, $Rs, $Rt]
+      - inst: SLTIU
+        data: [$Rd, $Rd, 1]
     derives:
       # - DefaultValue:
       #     value: Rs


### PR DESCRIPTION
As of right now, the implementation of the SEQ instruction seems to be invalid. For example, the following program
```
	li	$v0, 10
	li	$t0, 10
	seq	$v0, $v0, $t0
	dbg_print_int $v0        # expect 1 as $v0 == $t0

	li	$v0, 0
	seq	$v0, $zero, $v0
	dbg_print_int $v0        # expect 1 as $v0 == $zero

	li	$v0, 10
	seq	$v0, $zero, $v0
	dbg_print_int $v0        # expect 0 as $v0 != $zero

	li	$v0, 0
	seq	$v0, -10, $v0
	dbg_print_int $v0        # expect 0 as $v0 != -10
```
currently outputs `0000` rather than the expected `1100`. 

I rewrote the expansion of the pseudo-instruction in the yaml file, and after compiling and performing the same test on my machine, I now get the expected `1100` output. 

(if this gets merged, will it be updated on CSE soon enough such that I can use SEQ in my assignment 🤔)