### PR TITLE
Add 'mixed' base to mipsy_web

### DIFF
--- a/crates/mipsy_web/src/components/registers.rs
+++ b/crates/mipsy_web/src/components/registers.rs
@@ -6,9 +6,12 @@ use crate::worker::{Worker, WorkerRequest};
 use bounce::use_atom;
 use derivative::Derivative;
 use mipsy_lib::compile::breakpoints::{TargetAction, WatchpointTarget};
-use mipsy_lib::{Register, Safe};
+use mipsy_lib::{Register, Safe, KDATA_BOT, TEXT_BOT};
 use yew::{function_component, html, Callback, Properties, UseStateHandle};
 use yew_agent::UseBridgeHandle;
+
+const MIXED_BASE_MIN_ADDRESS: u32 = TEXT_BOT - 1024;
+const MIXED_BASE_MAX_ADDRESS: u32 = KDATA_BOT + 1024;
 
 #[derive(Properties, Derivative)]
 #[derivative(PartialEq)]
@@ -180,6 +183,15 @@ pub fn render_running_registers(props: &RegisterProps) -> Html {
                                                         RegisterBase::Binary => {
                                                             format!("0b{:b}", val)
                                                         },
+                                                        RegisterBase::Mixed => {
+                                                            let as_u32 = *val as u32;
+
+                                                            if (MIXED_BASE_MIN_ADDRESS..MIXED_BASE_MAX_ADDRESS).contains(&as_u32) {
+                                                                format!("0x{:08x}", as_u32)
+                                                            } else {
+                                                                format!("{}", val)
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             } else {

--- a/crates/mipsy_web/src/components/settings_modal.rs
+++ b/crates/mipsy_web/src/components/settings_modal.rs
@@ -164,7 +164,7 @@ pub fn render_modal(props: &ModalProps) -> Html {
                             hide_label={true}
                             selected_value={(*config).register_base.to_string()}
                             options={
-                                vec!["Hexadecimal".to_string(), "Decimal".to_string(), "Binary".to_string()]
+                                vec!["Hexadecimal".to_string(), "Decimal".to_string(), "Binary".to_string(), "Mixed".to_string()]
                             }
                         />
                         </div>

--- a/crates/mipsy_web/src/state/config.rs
+++ b/crates/mipsy_web/src/state/config.rs
@@ -106,6 +106,7 @@ pub enum RegisterBase {
     Hexadecimal,
     Decimal,
     Binary,
+    Mixed,
 }
 
 impl std::fmt::Display for RegisterBase {
@@ -114,6 +115,7 @@ impl std::fmt::Display for RegisterBase {
             RegisterBase::Hexadecimal => write!(f, "Hexadecimal"),
             RegisterBase::Decimal => write!(f, "Decimal"),
             RegisterBase::Binary => write!(f, "Binary"),
+            RegisterBase::Mixed => write!(f, "Mixed"),
         }
     }
 }
@@ -124,8 +126,15 @@ impl From<std::string::String> for RegisterBase {
             "Hexadecimal" => RegisterBase::Hexadecimal,
             "Decimal" => RegisterBase::Decimal,
             "Binary" => RegisterBase::Binary,
-            _ => RegisterBase::Hexadecimal,
+            "Mixed" => RegisterBase::Mixed,
+            _ => RegisterBase::default(),
         }
+    }
+}
+
+impl Default for RegisterBase {
+    fn default() -> Self {
+        RegisterBase::Decimal
     }
 }
 
@@ -142,7 +151,7 @@ impl Default for MipsyWebConfig {
             tab_size: 8,
             font_size: 14,
             monaco_theme: "vs".to_string(),
-            register_base: RegisterBase::Decimal,
+            register_base: RegisterBase::default(),
             // This is true as most CS1521 students don't need to see them
             hide_uncommon_registers: true,
         }


### PR DESCRIPTION
This adds a new 'mixed' base to mipsy_web. Small values (`< TEXT_BOT - 1024` or `>= KDATA_BOT + 1024`) are shown as signed decimal, all others are shown in hexadecimal. This means that memory addresses are shown in hexadecimal, and everything else is probably 'small', and so is shown in decimal (#279).