### PR TITLE
Implement open, read, write, close in compatible environments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,9 +776,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libgit2-sys"
@@ -843,6 +843,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "colored",
+ "libc",
  "mipsy_instructions",
  "mipsy_interactive",
  "mipsy_lib",
@@ -879,6 +880,7 @@ dependencies = [
  "colored",
  "ctrlc",
  "dirs 3.0.2",
+ "libc",
  "mipsy_instructions",
  "mipsy_lib",
  "mipsy_parser",

--- a/crates/mipsy/Cargo.toml
+++ b/crates/mipsy/Cargo.toml
@@ -7,15 +7,20 @@ build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["raw_io"]
+raw_io = ["libc", "mipsy_interactive/raw_io"]
+
 [dependencies]
 mipsy_lib = { version = "0.1.0", path = "../mipsy_lib" }
 mipsy_parser = { version = "0.1.0", path = "../mipsy_parser" }
-mipsy_interactive = { version = "0.1.0", path = "../mipsy_interactive" }
+mipsy_interactive = { version = "0.1.0", path = "../mipsy_interactive", default-features = false }
 mipsy_utils = { version = "0.1.0", path = "../mipsy_utils" }
 mipsy_instructions = { version = "0.1.0", path = "../mipsy_instructions", features = ["rt_yaml"] }
 clap = { version = "4.0.4", features = ["derive", "wrap_help"] } # cli arg parsing
 colored = "2"     # for ansi colors
 text_io = "0.1.8" # to read values in, w/out per line
+libc = { version = "0.2.152", optional = true }
 
 [build-dependencies]
 vergen = { version = "7.5.1", default-features = false, features = ["git"] } # for version info

--- a/crates/mipsy_interactive/Cargo.toml
+++ b/crates/mipsy_interactive/Cargo.toml
@@ -4,10 +4,11 @@ version = "0.1.0"
 authors = ["insou22 <zac.kologlu@gmail.com>"]
 edition = "2021"
 
-[lib]
-path = "src/lib.rs"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+default = ["raw_io"]
+raw_io = ["libc"]
 
 [dependencies]
 mipsy_lib          = { version = "0.1.0", path = "../mipsy_lib" }
@@ -25,3 +26,5 @@ text_io = "0.1.8"           # to read values in, w/out per line
 dirs = "3.0"                # for user config directory
 ctrlc = { version = "3.0", features = ["termination"] } # for interrupt handling during execution
 termsize = "0.1"            # to get terminal width info
+
+libc = { version = "0.2.152", optional = true }

--- a/crates/mipsy_interactive/src/interactive/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/mod.rs
@@ -422,77 +422,85 @@ impl State {
                         let value = runtime_handler::sys12_read_char(verbose);
                         self.runtime = guard(value);
                     }
+                    #[cfg(feature = "raw_io")]
+                    Open(args, guard) => {
+                        let value = runtime_handler::sys13_open(verbose, args);
+                        self.runtime = guard(value);
+                    }
+                    #[cfg(feature = "raw_io")]
+                    Read(args, guard) => {
+                        let value = runtime_handler::sys14_read(verbose, args);
+                        self.runtime = guard(value);
+                    }
+                    #[cfg(feature = "raw_io")]
+                    Write(args, guard) => {
+                        let value = runtime_handler::sys15_write(verbose, args);
+                        self.runtime = guard(value);
+                    }
+                    #[cfg(feature = "raw_io")]
+                    Close(args, guard) => {
+                        let value = runtime_handler::sys16_close(verbose, args);
+                        self.runtime = guard(value);
+                    }
+                    #[allow(unreachable_patterns)] // fall-through
                     Open(_args, guard) => {
-                        // TODO: implement file open for mipsy interactive frontend
-
                         let mut new_runtime = guard(-1);
                         new_runtime.timeline_mut().pop_last_state();
                         self.runtime = new_runtime;
+
                         return Err(CommandError::RuntimeError {
                             mipsy_error: MipsyError::Runtime(RuntimeError::new(
                                 Error::InvalidSyscall {
                                     syscall: SYS13_OPEN,
-                                    reason: InvalidSyscallReason::Unimplemented,
+                                    reason: InvalidSyscallReason::Disabled,
                                 },
                             )),
                         });
-
-                        // let value = runtime_handler::sys13_open(verbose, args);
-                        // self.runtime = Some(guard(value));
                     }
+                    #[allow(unreachable_patterns)] // fall-through
                     Read(_args, guard) => {
-                        // TODO: implement file read for mipsy interactive frontend
-
-                        let mut new_runtime = guard((-1, Vec::new()));
+                        let mut new_runtime = guard((-1, vec![]));
                         new_runtime.timeline_mut().pop_last_state();
                         self.runtime = new_runtime;
+
                         return Err(CommandError::RuntimeError {
                             mipsy_error: MipsyError::Runtime(RuntimeError::new(
                                 Error::InvalidSyscall {
                                     syscall: SYS14_READ,
-                                    reason: InvalidSyscallReason::Unimplemented,
+                                    reason: InvalidSyscallReason::Disabled,
                                 },
                             )),
                         });
-
-                        // let value = runtime_handler::sys14_read(verbose, args);
-                        // self.runtime = Some(guard(value));
                     }
+                    #[allow(unreachable_patterns)] // fall-through
                     Write(_args, guard) => {
-                        // TODO: implement file write for mipsy interactive frontend
-
                         let mut new_runtime = guard(-1);
                         new_runtime.timeline_mut().pop_last_state();
                         self.runtime = new_runtime;
+
                         return Err(CommandError::RuntimeError {
                             mipsy_error: MipsyError::Runtime(RuntimeError::new(
                                 Error::InvalidSyscall {
                                     syscall: SYS15_WRITE,
-                                    reason: InvalidSyscallReason::Unimplemented,
+                                    reason: InvalidSyscallReason::Disabled,
                                 },
                             )),
                         });
-
-                        // let value = runtime_handler::sys15_write(verbose, args);
-                        // self.runtime = Some(guard(value));
                     }
+                    #[allow(unreachable_patterns)] // fall-through
                     Close(_args, guard) => {
-                        // TODO: implement file close for mipsy interactive frontend
-
                         let mut new_runtime = guard(-1);
                         new_runtime.timeline_mut().pop_last_state();
                         self.runtime = new_runtime;
+
                         return Err(CommandError::RuntimeError {
                             mipsy_error: MipsyError::Runtime(RuntimeError::new(
                                 Error::InvalidSyscall {
                                     syscall: SYS16_CLOSE,
-                                    reason: InvalidSyscallReason::Unimplemented,
+                                    reason: InvalidSyscallReason::Disabled,
                                 },
                             )),
                         });
-
-                        // let value = runtime_handler::sys16_close(verbose, args);
-                        // self.runtime = Some(guard(value));
                     }
                     ExitStatus(args, new_runtime) => {
                         self.runtime = new_runtime;

--- a/crates/mipsy_lib/src/error/runtime/mod.rs
+++ b/crates/mipsy_lib/src/error/runtime/mod.rs
@@ -99,6 +99,7 @@ pub enum AlignmentRequirement {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum InvalidSyscallReason {
     Unimplemented, // Invalid becasue we don't have an implementation for it but it does exist
+    Disabled,      // The syscall is disabled (compilation flag)
     Unknown,       // Invalid because it doesn't exist to begin with
 }
 
@@ -977,6 +978,13 @@ impl Error {
                         // $v0 is a valid value, but mipsy doesn't implement the operation
                         error.push_str(&format!(
                             "\nthe syscall number `{}` is not implemented.\n",
+                            syscall.to_string().bold()
+                        ));
+                    }
+                    InvalidSyscallReason::Disabled => {
+                        // $v0 is a valid value, but mipsy doesn't implement the operation
+                        error.push_str(&format!(
+                            "\nthe syscall number `{}` is disabled; try enabling some features\n",
                             syscall.to_string().bold()
                         ));
                     }

--- a/crates/mipsy_parser/src/misc.rs
+++ b/crates/mipsy_parser/src/misc.rs
@@ -52,8 +52,8 @@ fn leftover_tokens_strip_multispace(i: Span<'_>, file_name: Option<Rc<str>>) -> 
     }
 }
 
-const IDENT_FIRST_CHAR: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_";
-const IDENT_CONTD_CHARS: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_0123456789.";
+const IDENT_FIRST_CHAR: &str = "$ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_";
+const IDENT_CONTD_CHARS: &str = "$ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_0123456789.";
 
 pub fn escape_char(char: char) -> String {
     match char {


### PR DESCRIPTION
The `raw_io` feature can be disabled on non-compatible environments like Windows

Closes #296