### PR TITLE
mipsy_web: fix undo/redo

### DIFF
--- a/crates/mipsy_web/index.html
+++ b/crates/mipsy_web/index.html
@@ -131,7 +131,11 @@
       }
 
       function set_editor_value(value="") {
-        window.editor.setValue(value);
+        // Don't unnecesarily call editor.setValue(),
+        // since setValue will also reset undo history.
+        if (get_editor_value() !== value) {
+          window.editor.setValue(value);
+        }
       }
 
       function get_editor_value() {


### PR DESCRIPTION
Calling `setValue` on the editor causes it to drop the current undo/redo history, and `set_editor_value` is called whenever the user changes the source code. This resulted in undo/redo not working at all. This commit changes `set_editor_value` to only call `setValue` when there's a difference between the new and old value.

There's likely a nicer way of fixing this that involves `set_editor_value` not being called as often -- but this change seemed least likely to introduce a bug related to a desync between the editor's and the app's view of the editor contents.