### PR TITLE
parse `.space default:amount`

### DIFF
--- a/crates/mipsy_lib/src/compile/data.rs
+++ b/crates/mipsy_lib/src/compile/data.rs
@@ -258,11 +258,19 @@ pub(super) fn eval_directive(
 
             align(binary, segment, multiple)
         }
-        MpDirective::Space(num) => {
+        MpDirective::Space((num, def)) => {
             let num =
-                eval_constant_in_range(num, u32::MIN as _, u32::MAX as _, binary, file_tag)? as u32;
+                eval_constant_in_range(num, u32::MIN as _, u32::MAX as _, binary, file_tag.clone())? as u32;
 
-            let space_byte = if config.spim {
+            let space_byte = if let Some(def) = def {
+                Safe::Valid(eval_constant_in_range(
+                    def,
+                    i8::MIN as _,
+                    u8::MAX as _,
+                    binary,
+                    file_tag,
+                )? as u8)
+            } else if config.spim {
                 Safe::Valid(0)
             } else {
                 Safe::Uninitialised

--- a/crates/mipsy_lib/src/compile/data.rs
+++ b/crates/mipsy_lib/src/compile/data.rs
@@ -259,8 +259,13 @@ pub(super) fn eval_directive(
             align(binary, segment, multiple)
         }
         MpDirective::Space((num, def)) => {
-            let num =
-                eval_constant_in_range(num, u32::MIN as _, u32::MAX as _, binary, file_tag.clone())? as u32;
+            let num = eval_constant_in_range(
+                num,
+                u32::MIN as _,
+                u32::MAX as _,
+                binary,
+                file_tag.clone(),
+            )? as u32;
 
             let space_byte = if let Some(def) = def {
                 Safe::Valid(eval_constant_in_range(

--- a/crates/mipsy_parser/src/directive.rs
+++ b/crates/mipsy_parser/src/directive.rs
@@ -35,7 +35,7 @@ pub enum MpDirective {
     Float(Vec<(f32, Option<MpConstValueLoc>)>),
     Double(Vec<(f64, Option<MpConstValueLoc>)>),
     Align(MpConstValueLoc),
-    Space(MpConstValueLoc),
+    Space((MpConstValueLoc, Option<MpConstValueLoc>)),
     Globl(String),
 }
 
@@ -141,6 +141,33 @@ fn parse_asciiz(i: Span<'_>) -> IResult<Span<'_>, MpDirective> {
     map(parse_ascii_type(".asciiz"), MpDirective::Asciiz)(i)
 }
 
+fn parse_def_len_num_type<'a, T: Clone>(
+    parser: fn(Span<'a>) -> IResult<Span<'a>, T>,
+) -> impl FnMut(Span<'a>) -> IResult<Span<'a>, (T, Option<MpConstValueLoc>)> {
+    alt((
+        map(
+            tuple((parser, space0, char(':'), space0, parse_constant_value)),
+            |(value, .., n)| (value, Some(n)),
+        ),
+        map(parser, |value| (value, None)),
+    ))
+}
+
+fn parse_single_num_type<'a, T: Clone>(
+    tag_str: &'static str,
+    parser: fn(Span<'a>) -> IResult<Span<'a>, T>,
+) -> impl FnMut(Span<'a>) -> IResult<Span<'a>, (T, Option<MpConstValueLoc>)> {
+    move |i| {
+        let (rem, (.., l)) = tuple((
+            tag(tag_str),
+            comment_multispace0,
+            parse_def_len_num_type(parser)
+        ))(i)?;
+
+        Ok((rem, l))
+    }
+}
+
 fn parse_num_type<'a, T: Clone>(
     tag_str: &'static str,
     parser: fn(Span<'a>) -> IResult<Span<'a>, T>,
@@ -151,13 +178,7 @@ fn parse_num_type<'a, T: Clone>(
             comment_multispace0,
             separated_list1(
                 map(tuple((space0, char(','), space0)), |_| ()),
-                alt((
-                    map(
-                        tuple((parser, space0, char(':'), space0, parse_constant_value)),
-                        |(value, _, _, _, n)| (value, Some(n)),
-                    ),
-                    map(parser, |value| (value, None)),
-                )),
+                parse_def_len_num_type(parser)
             ),
             opt(char(',')),
         ))(i)?;
@@ -207,7 +228,16 @@ fn parse_u32_type<'a>(
 }
 
 fn parse_space(i: Span<'_>) -> IResult<Span<'_>, MpDirective> {
-    map(parse_u32_type(".space"), MpDirective::Space)(i)
+    map(
+        map(
+            parse_single_num_type(".space", parse_constant_value),
+            |(d, n)| match n {
+                Some(n) => (n, Some(d)),
+                None => (d, None)
+            }
+        ),
+        MpDirective::Space,
+    )(i)
 }
 
 fn parse_align(i: Span<'_>) -> IResult<Span<'_>, MpDirective> {

--- a/crates/mipsy_parser/src/directive.rs
+++ b/crates/mipsy_parser/src/directive.rs
@@ -161,7 +161,7 @@ fn parse_single_num_type<'a, T: Clone>(
         let (rem, (.., l)) = tuple((
             tag(tag_str),
             comment_multispace0,
-            parse_def_len_num_type(parser)
+            parse_def_len_num_type(parser),
         ))(i)?;
 
         Ok((rem, l))
@@ -178,7 +178,7 @@ fn parse_num_type<'a, T: Clone>(
             comment_multispace0,
             separated_list1(
                 map(tuple((space0, char(','), space0)), |_| ()),
-                parse_def_len_num_type(parser)
+                parse_def_len_num_type(parser),
             ),
             opt(char(',')),
         ))(i)?;
@@ -233,8 +233,8 @@ fn parse_space(i: Span<'_>) -> IResult<Span<'_>, MpDirective> {
             parse_single_num_type(".space", parse_constant_value),
             |(d, n)| match n {
                 Some(n) => (n, Some(d)),
-                None => (d, None)
-            }
+                None => (d, None),
+            },
         ),
         MpDirective::Space,
     )(i)


### PR DESCRIPTION
also this pr doesnt fix this but currently `.byte default:amount` is allowed but i dont think it should be, i think the only reason it is is because theres already a parser for declaring with a comma seperated list aswell as `default:amount` and its just using that