### PR TITLE
perform constant operations on immediate values 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,8 +1013,7 @@ version = "0.1.0"
 dependencies = [
  "nom",
  "nom_locate",
- "proc-macro2",
- "quote",
+ "paste",
  "serde",
 ]
 
@@ -1139,6 +1138,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -349,7 +349,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -375,7 +375,7 @@ checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -474,7 +474,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -539,7 +539,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -559,7 +559,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1013,6 +1013,8 @@ version = "0.1.0"
 dependencies = [
  "nom",
  "nom_locate",
+ "proc-macro2",
+ "quote",
  "serde",
 ]
 
@@ -1220,7 +1222,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1383,7 +1385,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1480,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1497,7 +1499,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1557,7 +1559,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1740,7 +1742,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -1775,7 +1777,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2067,7 +2069,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -2088,7 +2090,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -2122,5 +2124,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.106",
 ]

--- a/crates/mipsy_lib/src/compile/checker.rs
+++ b/crates/mipsy_lib/src/compile/checker.rs
@@ -3,9 +3,7 @@ use std::rc::Rc;
 use mipsy_parser::{MpArgument, MpImmediate, MpItem, MpNumber};
 
 use crate::{
-    error::{compiler, ToMipsyResult},
-    inst::instruction::ToRegister,
-    Binary, CompilerError, MipsyError, MipsyResult, MpProgram, DATA_BOT, HEAP_BOT,
+    compile::data::eval_constant, error::{compiler, ToMipsyResult}, inst::instruction::ToRegister, Binary, CompilerError, MipsyError, MipsyResult, MpProgram, DATA_BOT, HEAP_BOT
 };
 
 pub enum Warning {}
@@ -62,20 +60,14 @@ pub fn check_post_data_label(program: &MpProgram, binary: &Binary) -> MipsyResul
                         MpArgument::Number(number) => match number {
                             MpNumber::Immediate(imm) => {
                                 check_imm(binary, imm, file_tag.clone(), line, *col, *col_end)?
-                            }
-                            MpNumber::BinaryOpImmediate(i1, _, i2) => {
-                                check_imm(binary, i1, file_tag.clone(), line, *col, *col_end)?;
-                                check_imm(binary, i2, file_tag.clone(), line, *col, *col_end)?;
+                            },
+                            MpNumber::Constant(cnst) => {
+                                check_imm(binary, &MpImmediate::I32(eval_constant(binary, cnst, file_tag.clone()).unwrap() as i32), file_tag.clone(), line, *col, *col_end)?
                             }
                             MpNumber::Float32(_) => {}
                             MpNumber::Float64(_) => {}
                             MpNumber::Char(_) => {}
-                        }, // MpArgument::LabelPlusConst(label, _const) => {
-                           //     if binary.constants.get(label).is_none() {
-                           //         binary.get_label(label)
-                           //             .into_compiler_mipsy_result(file_tag.clone(), line, *col, *col_end)?;
-                           //     }
-                           // }
+                        }
                     }
                 }
             }

--- a/crates/mipsy_lib/src/compile/checker.rs
+++ b/crates/mipsy_lib/src/compile/checker.rs
@@ -3,7 +3,6 @@ use std::rc::Rc;
 use mipsy_parser::{MpArgument, MpImmediate, MpItem, MpNumber};
 
 use crate::{
-    compile::data::eval_constant,
     error::{compiler, ToMipsyResult},
     inst::instruction::ToRegister,
     Binary, CompilerError, MipsyError, MipsyResult, MpProgram, DATA_BOT, HEAP_BOT,
@@ -32,7 +31,7 @@ pub fn check_pre(program: &MpProgram) -> MipsyResult<Vec<Warning>> {
                                 *col_end,
                             )?;
                         }
-                        MpArgument::Number(_) => {} // MpArgument::LabelPlusConst(..) => {}
+                        MpArgument::Number(_) => {}
                     }
                 }
             }
@@ -58,24 +57,8 @@ pub fn check_post_data_label(program: &MpProgram, binary: &Binary) -> MipsyResul
         match item {
             MpItem::Instruction(ref instruction) => {
                 for (argument, col, col_end) in instruction.arguments() {
-                    match argument {
-                        MpArgument::Register(_) => {}
-                        MpArgument::Number(number) => match number {
-                            MpNumber::Immediate(imm) => {
-                                check_imm(binary, imm, file_tag.clone(), line, *col, *col_end)?
-                            }
-                            MpNumber::Constant(cnst) => check_imm(
-                                binary,
-                                &eval_constant(binary, cnst, file_tag.clone())?.into(),
-                                file_tag.clone(),
-                                line,
-                                *col,
-                                *col_end,
-                            )?,
-                            MpNumber::Float32(_) => {}
-                            MpNumber::Float64(_) => {}
-                            MpNumber::Char(_) => {}
-                        },
+                    if let MpArgument::Number(MpNumber::Immediate(imm)) = argument {
+                        check_imm(binary, imm, file_tag.clone(), line, *col, *col_end)?
                     }
                 }
             }

--- a/crates/mipsy_lib/src/compile/checker.rs
+++ b/crates/mipsy_lib/src/compile/checker.rs
@@ -3,7 +3,10 @@ use std::rc::Rc;
 use mipsy_parser::{MpArgument, MpImmediate, MpItem, MpNumber};
 
 use crate::{
-    compile::data::eval_constant, error::{compiler, ToMipsyResult}, inst::instruction::ToRegister, Binary, CompilerError, MipsyError, MipsyResult, MpProgram, DATA_BOT, HEAP_BOT
+    compile::data::eval_constant,
+    error::{compiler, ToMipsyResult},
+    inst::instruction::ToRegister,
+    Binary, CompilerError, MipsyError, MipsyResult, MpProgram, DATA_BOT, HEAP_BOT,
 };
 
 pub enum Warning {}
@@ -60,14 +63,19 @@ pub fn check_post_data_label(program: &MpProgram, binary: &Binary) -> MipsyResul
                         MpArgument::Number(number) => match number {
                             MpNumber::Immediate(imm) => {
                                 check_imm(binary, imm, file_tag.clone(), line, *col, *col_end)?
-                            },
-                            MpNumber::Constant(cnst) => {
-                                check_imm(binary, &MpImmediate::I32(eval_constant(binary, cnst, file_tag.clone()).unwrap() as i32), file_tag.clone(), line, *col, *col_end)?
                             }
+                            MpNumber::Constant(cnst) => check_imm(
+                                binary,
+                                &eval_constant(binary, cnst, file_tag.clone())?.into(),
+                                file_tag.clone(),
+                                line,
+                                *col,
+                                *col_end,
+                            )?,
                             MpNumber::Float32(_) => {}
                             MpNumber::Float64(_) => {}
                             MpNumber::Char(_) => {}
-                        }
+                        },
                     }
                 }
             }

--- a/crates/mipsy_lib/src/compile/data.rs
+++ b/crates/mipsy_lib/src/compile/data.rs
@@ -456,7 +456,7 @@ pub fn populate_labels_and_data(
     Ok(())
 }
 
-fn eval_constant(binary: &Binary, constant: &MpConstValueLoc, file: Rc<str>) -> MipsyResult<i64> {
+pub fn eval_constant(binary: &Binary, constant: &MpConstValueLoc, file: Rc<str>) -> MipsyResult<i64> {
     Ok(match &constant.0 {
         &MpConstValue::Value(value) => value as _,
         MpConstValue::Const(label) => binary

--- a/crates/mipsy_lib/src/compile/data.rs
+++ b/crates/mipsy_lib/src/compile/data.rs
@@ -1,10 +1,10 @@
-use std::rc::Rc;
+use std::{ops::Range, rc::Rc};
 
 use super::{bytes::ToBytes, text::instruction_length, Binary, DATA_BOT, TEXT_BOT};
 use crate::{
     error::{
         compiler::{DirectiveType, Error},
-        ToMipsyResult,
+        InternalError, MipsyInternalResult, ToMipsyResult,
     },
     inst::instruction::InstSet,
     util::Safe,
@@ -101,16 +101,14 @@ pub(super) fn eval_directive(
                 Ok((
                     eval_constant_in_range(
                         byte,
-                        i8::MIN as _,
-                        u8::MAX as _,
+                        i8::MIN as _..u8::MAX as _,
                         binary,
                         file_tag.clone(),
                     )? as u8,
                     if let Some(n) = n {
                         eval_constant_in_range(
                             n,
-                            u32::MIN as _,
-                            u32::MAX as _,
+                            u32::MIN as _..u32::MAX as _,
                             binary,
                             file_tag.clone(),
                         )? as u32
@@ -132,16 +130,14 @@ pub(super) fn eval_directive(
                     Ok((
                         eval_constant_in_range(
                             half,
-                            i16::MIN as _,
-                            u16::MAX as _,
+                            i16::MIN as _..u16::MAX as _,
                             binary,
                             file_tag.clone(),
                         )? as u16,
                         if let Some(n) = n {
                             eval_constant_in_range(
                                 n,
-                                u32::MIN as _,
-                                u32::MAX as _,
+                                u32::MIN as _..u32::MAX as _,
                                 binary,
                                 file_tag.clone(),
                             )? as u32
@@ -167,16 +163,14 @@ pub(super) fn eval_directive(
                     Ok((
                         eval_constant_in_range(
                             word,
-                            i32::MIN as _,
-                            u32::MAX as _,
+                            i32::MIN as _..u32::MAX as _,
                             binary,
                             file_tag.clone(),
                         )? as u32,
                         if let Some(n) = n {
                             eval_constant_in_range(
                                 n,
-                                u32::MIN as _,
-                                u32::MAX as _,
+                                u32::MIN as _..u32::MAX as _,
                                 binary,
                                 file_tag.clone(),
                             )? as u32
@@ -204,8 +198,7 @@ pub(super) fn eval_directive(
                         if let Some(n) = n {
                             eval_constant_in_range(
                                 n,
-                                u32::MIN as _,
-                                u32::MAX as _,
+                                u32::MIN as _..u32::MAX as _,
                                 binary,
                                 file_tag.clone(),
                             )? as u32
@@ -233,8 +226,7 @@ pub(super) fn eval_directive(
                         if let Some(n) = n {
                             eval_constant_in_range(
                                 n,
-                                u32::MIN as _,
-                                u32::MAX as _,
+                                u32::MIN as _..u32::MAX as _,
                                 binary,
                                 file_tag.clone(),
                             )? as u32
@@ -252,7 +244,7 @@ pub(super) fn eval_directive(
             alignment.into_iter().chain(doubles).collect()
         }
         MpDirective::Align(num) => {
-            let num = eval_constant_in_range(num, u32::MIN as _, 31, binary, file_tag)? as u32;
+            let num = eval_constant_in_range(num, u32::MIN as _..31, binary, file_tag)? as u32;
 
             let multiple = 2usize.pow(num);
 
@@ -260,7 +252,7 @@ pub(super) fn eval_directive(
         }
         MpDirective::Space(num) => {
             let num =
-                eval_constant_in_range(num, u32::MIN as _, u32::MAX as _, binary, file_tag)? as u32;
+                eval_constant_in_range(num, u32::MIN as _..u32::MAX as _, binary, file_tag)? as u32;
 
             let space_byte = if config.spim {
                 Safe::Valid(0)
@@ -334,13 +326,29 @@ pub fn populate_labels_and_data(
                 }
             }
             MpItem::Instruction(instruction) => {
+                let is = instruction.clone();
                 for arg in instruction.arguments_mut() {
                     if let MpArgument::Number(MpNumber::Immediate(MpImmediate::LabelReference(
                         ref label,
                     ))) = arg.0
                     {
                         if let Some(&value) = binary.constants.get(label) {
-                            arg.0 = MpArgument::Number(MpNumber::Immediate(value.into()))
+                            arg.0 = MpArgument::Number(MpNumber::Immediate(
+                                value.try_into().map_err(|_| {
+                                    MipsyError::Compiler(CompilerError::new(
+                                        Error::ConstantValueDoesNotFit {
+                                            directive_type: DirectiveType::Byte,
+                                            value: value,
+                                            range_low: i32::MIN as _,
+                                            range_high: u32::MAX as _,
+                                        },
+                                        file_tag.clone(),
+                                        is.line(),
+                                        is.col(),
+                                        is.col_end(),
+                                    ))
+                                })?,
+                            ))
                         }
                     }
                 }
@@ -359,13 +367,15 @@ pub fn populate_labels_and_data(
                     Segment::Text => (TEXT_BOT, &mut text_len),
                     Segment::KText => (KTEXT_BOT, &mut ktext_len),
                     _ => {
-                        return Err(MipsyError::Compiler(CompilerError::new(
-                            Error::InstructionInDataSegment,
-                            file_tag,
-                            instruction.line(),
-                            instruction.col(),
-                            instruction.col_end(),
-                        )));
+                        return Err(MipsyError::Compiler(
+                            crate::error::compiler::CompilerError::new(
+                                Error::InstructionInDataSegment,
+                                file_tag,
+                                instruction.line(),
+                                instruction.col(),
+                                instruction.col_end(),
+                            ),
+                        ));
                     }
                 };
 
@@ -444,7 +454,9 @@ pub fn eval_constant(
     file: Rc<str>,
 ) -> MipsyResult<i64> {
     let err = MipsyError::Compiler(CompilerError::new(
-        Error::ConstantEvaluationDoesNotFit,
+        Error::ConstantExpressionDoesNotFit {
+            eval: "test".into(),
+        },
         file.clone(),
         constant.1.line(),
         constant.1.col(),
@@ -507,29 +519,37 @@ pub fn eval_constant(
 
 fn eval_constant_in_range(
     constant: &MpConstValueLoc,
-    range_low: i64,
-    range_high: i64,
+    range: Range<i64>,
     binary: &Binary,
     file: Rc<str>,
 ) -> MipsyResult<i64> {
-    let value = eval_constant(binary, constant, file.clone())?;
+    eval_value_in_range(eval_constant(binary, constant, file.clone())?, range).map_err(
+        |e| match e {
+            InternalError::Compiler(c) if matches!(c, Error::ConstantValueDoesNotFit { .. }) => {
+                MipsyError::Compiler(CompilerError::new(
+                    c,
+                    file,
+                    constant.1.line(),
+                    constant.1.col(),
+                    constant.1.col_end(),
+                ))
+            }
+            _ => unreachable!(),
+        },
+    )
+}
 
-    if value < range_low || value > range_high {
-        return Err(MipsyError::Compiler(CompilerError::new(
-            Error::ConstantValueDoesNotFit {
-                directive_type: DirectiveType::Byte,
-                value,
-                range_low,
-                range_high,
-            },
-            file,
-            constant.1.line(),
-            constant.1.col(),
-            constant.1.col_end(),
-        )));
+pub fn eval_value_in_range(value: i64, range: Range<i64>) -> MipsyInternalResult<i64> {
+    if value < range.start || value > range.end {
+        Err(InternalError::Compiler(Error::ConstantValueDoesNotFit {
+            directive_type: DirectiveType::Byte,
+            value,
+            range_high: range.start,
+            range_low: range.end,
+        }))
+    } else {
+        Ok(value)
     }
-
-    Ok(value)
 }
 
 fn insert_safe_data(segment: &Segment, binary: &mut Binary, values: &[Safe<u8>]) {

--- a/crates/mipsy_lib/src/compile/data.rs
+++ b/crates/mipsy_lib/src/compile/data.rs
@@ -459,7 +459,7 @@ pub fn eval_constant(
 ) -> MipsyResult<i64> {
     let err = MipsyError::Compiler(CompilerError::new(
         Error::ConstantExpressionDoesNotFit {
-            eval: "anon".into(),
+            eval: "anonymous expression".into(),
         },
         file.clone(),
         constant.1.line(),
@@ -469,27 +469,24 @@ pub fn eval_constant(
 
     match &constant.0 {
         &MpConstValue::Value(value) => Some(value as _),
-        MpConstValue::Const(label) => {
-            println!("{label:?}");
-            Some(
-                binary
-                    .constants
-                    .get(label)
-                    .copied()
-                    .or_else(|| binary.get_label(label).map(|x| x as i64).ok())
-                    .ok_or_else(|| {
-                        MipsyError::Compiler(CompilerError::new(
-                            Error::UnresolvedConstant {
-                                label: label.to_string(),
-                            },
-                            file.clone(),
-                            constant.1.line(),
-                            constant.1.col(),
-                            constant.1.col_end(),
-                        ))
-                    })?,
-            )
-        }
+        MpConstValue::Const(label) => Some(
+            binary
+                .constants
+                .get(label)
+                .copied()
+                .or_else(|| binary.get_label(label).map(|x| x as i64).ok())
+                .ok_or_else(|| {
+                    MipsyError::Compiler(CompilerError::new(
+                        Error::UnresolvedConstant {
+                            label: label.to_string(),
+                        },
+                        file.clone(),
+                        constant.1.line(),
+                        constant.1.col(),
+                        constant.1.col_end(),
+                    ))
+                })?,
+        ),
         MpConstValue::Minus(value) => Some(-eval_constant(binary, value, file)?),
         MpConstValue::Sum(v1, v2) => {
             eval_constant(binary, v1, file.clone())?.checked_add(eval_constant(binary, v2, file)?)

--- a/crates/mipsy_lib/src/compile/data.rs
+++ b/crates/mipsy_lib/src/compile/data.rs
@@ -443,57 +443,66 @@ pub fn eval_constant(
     constant: &MpConstValueLoc,
     file: Rc<str>,
 ) -> MipsyResult<i64> {
-    Ok(match &constant.0 {
-        &MpConstValue::Value(value) => value as _,
-        MpConstValue::Const(label) => binary
-            .constants
-            .get(label)
-            .copied()
-            .or_else(|| binary.get_label(label).map(|x| x as i64).ok())
-            .ok_or_else(|| {
-                MipsyError::Compiler(CompilerError::new(
-                    Error::UnresolvedConstant {
-                        label: label.to_string(),
-                    },
-                    file.clone(),
-                    constant.1.line(),
-                    constant.1.col(),
-                    constant.1.col_end(),
-                ))
-            })?,
-        MpConstValue::Minus(value) => -eval_constant(binary, value, file)?,
+    let err = MipsyError::Compiler(CompilerError::new(
+        Error::ConstantEvaluationDoesNotFit,
+        file.clone(),
+        constant.1.line(),
+        constant.1.col(),
+        constant.1.col_end(),
+    ));
+
+    match &constant.0 {
+        &MpConstValue::Value(value) => Some(value as _),
+        MpConstValue::Const(label) => Some(
+            binary
+                .constants
+                .get(label)
+                .copied()
+                .or_else(|| binary.get_label(label).map(|x| x as i64).ok())
+                .ok_or_else(|| {
+                    MipsyError::Compiler(CompilerError::new(
+                        Error::UnresolvedConstant {
+                            label: label.to_string(),
+                        },
+                        file.clone(),
+                        constant.1.line(),
+                        constant.1.col(),
+                        constant.1.col_end(),
+                    ))
+                })?,
+        ),
+        MpConstValue::Minus(value) => Some(-eval_constant(binary, value, file)?),
         MpConstValue::Sum(v1, v2) => {
-            eval_constant(binary, v1, file.clone())? + eval_constant(binary, v2, file)?
+            eval_constant(binary, v1, file.clone())?.checked_add(eval_constant(binary, v2, file)?)
         }
         MpConstValue::Sub(v1, v2) => {
-            eval_constant(binary, v1, file.clone())? - eval_constant(binary, v2, file)?
+            eval_constant(binary, v1, file.clone())?.checked_sub(eval_constant(binary, v2, file)?)
         }
         MpConstValue::Div(v1, v2) => {
-            eval_constant(binary, v1, file.clone())? / eval_constant(binary, v2, file)?
+            eval_constant(binary, v1, file.clone())?.checked_div(eval_constant(binary, v2, file)?)
         }
         MpConstValue::Mult(v1, v2) => {
-            eval_constant(binary, v1, file.clone())? * eval_constant(binary, v2, file)?
+            eval_constant(binary, v1, file.clone())?.checked_mul(eval_constant(binary, v2, file)?)
         }
         MpConstValue::Mod(v1, v2) => {
-            eval_constant(binary, v1, file.clone())? % eval_constant(binary, v2, file)?
+            eval_constant(binary, v1, file.clone())?.checked_rem(eval_constant(binary, v2, file)?)
         }
         MpConstValue::And(v1, v2) => {
-            eval_constant(binary, v1, file.clone())? & eval_constant(binary, v2, file)?
+            Some(eval_constant(binary, v1, file.clone())? & eval_constant(binary, v2, file)?)
         }
         MpConstValue::Or(v1, v2) => {
-            eval_constant(binary, v1, file.clone())? | eval_constant(binary, v2, file)?
+            Some(eval_constant(binary, v1, file.clone())? | eval_constant(binary, v2, file)?)
         }
         MpConstValue::Xor(v1, v2) => {
-            eval_constant(binary, v1, file.clone())? ^ eval_constant(binary, v2, file)?
+            Some(eval_constant(binary, v1, file.clone())? ^ eval_constant(binary, v2, file)?)
         }
-        MpConstValue::Neg(value) => !eval_constant(binary, value, file)?,
-        MpConstValue::Shl(v1, v2) => {
-            eval_constant(binary, v1, file.clone())? << eval_constant(binary, v2, file)?
-        }
-        MpConstValue::Shr(v1, v2) => {
-            eval_constant(binary, v1, file.clone())? >> eval_constant(binary, v2, file)?
-        }
-    })
+        MpConstValue::Neg(value) => Some(!eval_constant(binary, value, file)?),
+        MpConstValue::Shl(v1, v2) => (eval_constant(binary, v1, file.clone())?)
+            .checked_shl(eval_constant(binary, v2, file)? as _),
+        MpConstValue::Shr(v1, v2) => (eval_constant(binary, v1, file.clone())?)
+            .checked_shr(eval_constant(binary, v2, file)? as _),
+    }
+    .ok_or(err)
 }
 
 fn eval_constant_in_range(

--- a/crates/mipsy_lib/src/compile/data.rs
+++ b/crates/mipsy_lib/src/compile/data.rs
@@ -1,4 +1,7 @@
-use std::{ops::{Bound, Range, RangeBounds}, rc::Rc};
+use std::{
+    ops::{Bound, Range, RangeBounds},
+    rc::Rc,
+};
 
 use super::{bytes::ToBytes, text::instruction_length, Binary, DATA_BOT, TEXT_BOT};
 use crate::{
@@ -252,7 +255,8 @@ pub(super) fn eval_directive(
         }
         MpDirective::Space(num) => {
             let num =
-                eval_constant_in_range(num, u32::MIN as i64..=u32::MAX as _, binary, file_tag)? as u32;
+                eval_constant_in_range(num, u32::MIN as i64..=u32::MAX as _, binary, file_tag)?
+                    as u32;
 
             let space_byte = if config.spim {
                 Safe::Valid(0)
@@ -546,7 +550,7 @@ pub fn eval_value_in_range(value: i64, range: impl RangeBounds<i64>) -> MipsyInt
     let bound_val = |b: Bound<&i64>| match b {
         Bound::Included(&x) => x,
         Bound::Excluded(&x) => x.saturating_sub(1),
-        Bound::Unbounded => unreachable!()
+        Bound::Unbounded => unreachable!(),
     };
     let (start, end) = (bound_val(range.start_bound()), bound_val(range.end_bound()));
     if value < start || value > end {

--- a/crates/mipsy_lib/src/compile/data.rs
+++ b/crates/mipsy_lib/src/compile/data.rs
@@ -340,25 +340,7 @@ pub fn populate_labels_and_data(
                     ))) = arg.0
                     {
                         if let Some(&value) = binary.constants.get(label) {
-                            if u16::MIN as i64 <= value && u16::MAX as i64 >= value {
-                                arg.0 = MpArgument::Number(MpNumber::Immediate(MpImmediate::U16(
-                                    value as _,
-                                )));
-                            } else if i16::MIN as i64 <= value && i16::MAX as i64 >= value {
-                                arg.0 = MpArgument::Number(MpNumber::Immediate(MpImmediate::I16(
-                                    value as _,
-                                )));
-                            } else if u32::MIN as i64 <= value && u32::MAX as i64 >= value {
-                                arg.0 = MpArgument::Number(MpNumber::Immediate(MpImmediate::U32(
-                                    value as _,
-                                )));
-                            } else if i32::MIN as i64 <= value && i32::MAX as i64 >= value {
-                                arg.0 = MpArgument::Number(MpNumber::Immediate(MpImmediate::I32(
-                                    value as _,
-                                )));
-                            } else {
-                                todo!();
-                            }
+                            arg.0 = MpArgument::Number(MpNumber::Immediate(value.into()))
                         }
                     }
                 }
@@ -366,7 +348,7 @@ pub fn populate_labels_and_data(
                 // We can't compile instructions yet - so just keep track of
                 // how many bytes-worth we've seen so far
                 let inst_length =
-                    instruction_length(iset, instruction).into_compiler_mipsy_result(
+                    instruction_length(binary, iset, instruction).into_compiler_mipsy_result(
                         file_tag.clone(),
                         line,
                         instruction.col(),
@@ -456,7 +438,11 @@ pub fn populate_labels_and_data(
     Ok(())
 }
 
-pub fn eval_constant(binary: &Binary, constant: &MpConstValueLoc, file: Rc<str>) -> MipsyResult<i64> {
+pub fn eval_constant(
+    binary: &Binary,
+    constant: &MpConstValueLoc,
+    file: Rc<str>,
+) -> MipsyResult<i64> {
     Ok(match &constant.0 {
         &MpConstValue::Value(value) => value as _,
         MpConstValue::Const(label) => binary

--- a/crates/mipsy_lib/src/compile/data.rs
+++ b/crates/mipsy_lib/src/compile/data.rs
@@ -455,7 +455,7 @@ pub fn eval_constant(
 ) -> MipsyResult<i64> {
     let err = MipsyError::Compiler(CompilerError::new(
         Error::ConstantExpressionDoesNotFit {
-            eval: "test".into(),
+            eval: "anon".into(),
         },
         file.clone(),
         constant.1.line(),
@@ -465,24 +465,27 @@ pub fn eval_constant(
 
     match &constant.0 {
         &MpConstValue::Value(value) => Some(value as _),
-        MpConstValue::Const(label) => Some(
-            binary
-                .constants
-                .get(label)
-                .copied()
-                .or_else(|| binary.get_label(label).map(|x| x as i64).ok())
-                .ok_or_else(|| {
-                    MipsyError::Compiler(CompilerError::new(
-                        Error::UnresolvedConstant {
-                            label: label.to_string(),
-                        },
-                        file.clone(),
-                        constant.1.line(),
-                        constant.1.col(),
-                        constant.1.col_end(),
-                    ))
-                })?,
-        ),
+        MpConstValue::Const(label) => {
+            println!("{label:?}");
+            Some(
+                binary
+                    .constants
+                    .get(label)
+                    .copied()
+                    .or_else(|| binary.get_label(label).map(|x| x as i64).ok())
+                    .ok_or_else(|| {
+                        MipsyError::Compiler(CompilerError::new(
+                            Error::UnresolvedConstant {
+                                label: label.to_string(),
+                            },
+                            file.clone(),
+                            constant.1.line(),
+                            constant.1.col(),
+                            constant.1.col_end(),
+                        ))
+                    })?,
+            )
+        }
         MpConstValue::Minus(value) => Some(-eval_constant(binary, value, file)?),
         MpConstValue::Sum(v1, v2) => {
             eval_constant(binary, v1, file.clone())?.checked_add(eval_constant(binary, v2, file)?)
@@ -540,12 +543,12 @@ fn eval_constant_in_range(
 }
 
 pub fn eval_value_in_range(value: i64, range: Range<i64>) -> MipsyInternalResult<i64> {
-    if value < range.start || value > range.end {
+    if value < range.start || value > range.end.saturating_sub(1) {
         Err(InternalError::Compiler(Error::ConstantValueDoesNotFit {
             directive_type: DirectiveType::Byte,
             value,
+            range_low: range.end.saturating_sub(1),
             range_high: range.start,
-            range_low: range.end,
         }))
     } else {
         Ok(value)

--- a/crates/mipsy_lib/src/compile/data.rs
+++ b/crates/mipsy_lib/src/compile/data.rs
@@ -1,4 +1,4 @@
-use std::{ops::Range, rc::Rc};
+use std::{ops::{Bound, Range, RangeBounds}, rc::Rc};
 
 use super::{bytes::ToBytes, text::instruction_length, Binary, DATA_BOT, TEXT_BOT};
 use crate::{
@@ -101,14 +101,14 @@ pub(super) fn eval_directive(
                 Ok((
                     eval_constant_in_range(
                         byte,
-                        i8::MIN as _..u8::MAX as _,
+                        i8::MIN as i64..=u8::MAX as _,
                         binary,
                         file_tag.clone(),
                     )? as u8,
                     if let Some(n) = n {
                         eval_constant_in_range(
                             n,
-                            u32::MIN as _..u32::MAX as _,
+                            u32::MIN as i64..=u32::MAX as _,
                             binary,
                             file_tag.clone(),
                         )? as u32
@@ -130,14 +130,14 @@ pub(super) fn eval_directive(
                     Ok((
                         eval_constant_in_range(
                             half,
-                            i16::MIN as _..u16::MAX as _,
+                            i16::MIN as i64..=u16::MAX as _,
                             binary,
                             file_tag.clone(),
                         )? as u16,
                         if let Some(n) = n {
                             eval_constant_in_range(
                                 n,
-                                u32::MIN as _..u32::MAX as _,
+                                u32::MIN as i64..=u32::MAX as _,
                                 binary,
                                 file_tag.clone(),
                             )? as u32
@@ -163,14 +163,14 @@ pub(super) fn eval_directive(
                     Ok((
                         eval_constant_in_range(
                             word,
-                            i32::MIN as _..u32::MAX as _,
+                            i32::MIN as i64..=u32::MAX as _,
                             binary,
                             file_tag.clone(),
                         )? as u32,
                         if let Some(n) = n {
                             eval_constant_in_range(
                                 n,
-                                u32::MIN as _..u32::MAX as _,
+                                u32::MIN as i64..=u32::MAX as _,
                                 binary,
                                 file_tag.clone(),
                             )? as u32
@@ -198,7 +198,7 @@ pub(super) fn eval_directive(
                         if let Some(n) = n {
                             eval_constant_in_range(
                                 n,
-                                u32::MIN as _..u32::MAX as _,
+                                u32::MIN as i64..=u32::MAX as _,
                                 binary,
                                 file_tag.clone(),
                             )? as u32
@@ -226,7 +226,7 @@ pub(super) fn eval_directive(
                         if let Some(n) = n {
                             eval_constant_in_range(
                                 n,
-                                u32::MIN as _..u32::MAX as _,
+                                u32::MIN as i64..=u32::MAX as _,
                                 binary,
                                 file_tag.clone(),
                             )? as u32
@@ -244,7 +244,7 @@ pub(super) fn eval_directive(
             alignment.into_iter().chain(doubles).collect()
         }
         MpDirective::Align(num) => {
-            let num = eval_constant_in_range(num, u32::MIN as _..31, binary, file_tag)? as u32;
+            let num = eval_constant_in_range(num, u32::MIN as _..32, binary, file_tag)? as u32;
 
             let multiple = 2usize.pow(num);
 
@@ -252,7 +252,7 @@ pub(super) fn eval_directive(
         }
         MpDirective::Space(num) => {
             let num =
-                eval_constant_in_range(num, u32::MIN as _..u32::MAX as _, binary, file_tag)? as u32;
+                eval_constant_in_range(num, u32::MIN as i64..=u32::MAX as _, binary, file_tag)? as u32;
 
             let space_byte = if config.spim {
                 Safe::Valid(0)
@@ -522,7 +522,7 @@ pub fn eval_constant(
 
 fn eval_constant_in_range(
     constant: &MpConstValueLoc,
-    range: Range<i64>,
+    range: impl RangeBounds<i64>,
     binary: &Binary,
     file: Rc<str>,
 ) -> MipsyResult<i64> {
@@ -542,13 +542,19 @@ fn eval_constant_in_range(
     )
 }
 
-pub fn eval_value_in_range(value: i64, range: Range<i64>) -> MipsyInternalResult<i64> {
-    if value < range.start || value > range.end.saturating_sub(1) {
+pub fn eval_value_in_range(value: i64, range: impl RangeBounds<i64>) -> MipsyInternalResult<i64> {
+    let bound_val = |b: Bound<&i64>| match b {
+        Bound::Included(&x) => x,
+        Bound::Excluded(&x) => x.saturating_sub(1),
+        Bound::Unbounded => unreachable!()
+    };
+    let (start, end) = (bound_val(range.start_bound()), bound_val(range.end_bound()));
+    if value < start || value > end {
         Err(InternalError::Compiler(Error::ConstantValueDoesNotFit {
             directive_type: DirectiveType::Byte,
             value,
-            range_low: range.end.saturating_sub(1),
-            range_high: range.start,
+            range_low: start,
+            range_high: end,
         }))
     } else {
         Ok(value)

--- a/crates/mipsy_lib/src/compile/mod.rs
+++ b/crates/mipsy_lib/src/compile/mod.rs
@@ -12,7 +12,7 @@ pub mod breakpoints;
 mod checker;
 pub use checker::{check_post_data_label, check_pre};
 
-mod data;
+pub mod data;
 use data::populate_labels_and_data;
 
 mod text;

--- a/crates/mipsy_lib/src/compile/text.rs
+++ b/crates/mipsy_lib/src/compile/text.rs
@@ -21,14 +21,12 @@ pub fn find_instruction<'a>(
     } else if let Some(pseudo) = iset.find_pseudo(inst, program) {
         Ok(SignatureRef::Pseudo(pseudo))
     } else {
+        iset.find_errors(inst, program)?;
+
         let mut matching_names: Vec<SignatureRef<'a>> = vec![];
         let mut close_names: Vec<SignatureRef<'a>> = vec![];
 
-        let all_instns = iset
-            .native_set()
-            .iter()
-            .map(SignatureRef::Native)
-            .chain(iset.pseudo_set().iter().map(SignatureRef::Pseudo));
+        let all_instns = iset.both_sets();
 
         for real_inst in all_instns {
             if real_inst.name() == inst.name() {

--- a/crates/mipsy_lib/src/compile/text.rs
+++ b/crates/mipsy_lib/src/compile/text.rs
@@ -12,12 +12,13 @@ use mipsy_parser::{MpInstruction, MpItem};
 use mipsy_utils::MipsyConfig;
 
 pub fn find_instruction<'a>(
+    program: &Binary,
     iset: &'a InstSet,
     inst: &MpInstruction,
 ) -> MipsyInternalResult<SignatureRef<'a>> {
-    if let Some(native) = iset.find_native(inst) {
+    if let Some(native) = iset.find_native(inst, program) {
         Ok(SignatureRef::Native(native))
-    } else if let Some(pseudo) = iset.find_pseudo(inst) {
+    } else if let Some(pseudo) = iset.find_pseudo(inst, program) {
         Ok(SignatureRef::Pseudo(pseudo))
     } else {
         let mut matching_names: Vec<SignatureRef<'a>> = vec![];
@@ -63,8 +64,12 @@ pub fn find_instruction<'a>(
     }
 }
 
-pub fn instruction_length(iset: &InstSet, inst: &MpInstruction) -> MipsyInternalResult<usize> {
-    Ok(match find_instruction(iset, inst)? {
+pub fn instruction_length(
+    binary: &Binary,
+    iset: &InstSet,
+    inst: &MpInstruction,
+) -> MipsyInternalResult<usize> {
+    Ok(match find_instruction(binary, iset, inst)? {
         SignatureRef::Native(_) => 1,
         SignatureRef::Pseudo(pseudo) => pseudo.expansion().len(),
     })
@@ -75,7 +80,7 @@ pub fn compile1(
     iset: &InstSet,
     inst: &MpInstruction,
 ) -> MipsyInternalResult<Vec<u32>> {
-    find_instruction(iset, inst)?.compile_ops(binary, iset, inst)
+    find_instruction(binary, iset, inst)?.compile_ops(binary, iset, inst)
 }
 
 pub fn populate_text(

--- a/crates/mipsy_lib/src/error/compiler/mod.rs
+++ b/crates/mipsy_lib/src/error/compiler/mod.rs
@@ -180,13 +180,13 @@ pub enum Error {
     UnresolvedConstant {
         label: String,
     },
-
     ConstantValueDoesNotFit {
         directive_type: DirectiveType,
         value: i64,
         range_low: i64,
         range_high: i64,
     },
+    ConstantEvaluationDoesNotFit,
 
     DataInTextSegment {
         directive_type: MpDirective,
@@ -215,7 +215,7 @@ impl Error {
                 let register_dollar = "$".yellow().bold();
                 let register_num = reg_num.to_string().bold();
 
-                format!("{} {}{}", message, register_dollar, register_num)
+                format!("{message} {register_dollar}{register_num}")
             }
 
             Error::NamedRegisterOutOfRange {
@@ -227,7 +227,7 @@ impl Error {
                 let reg_name = reg_name.to_string().bold();
                 let reg_index = reg_index.to_string().bold();
 
-                format!("{} {}{}{}", message, register_dollar, reg_name, reg_index)
+                format!("{message} {register_dollar}{reg_name}{reg_index}")
             }
 
             Error::UnknownRegister { reg_name } => {
@@ -235,13 +235,13 @@ impl Error {
                 let register_dollar = "$".yellow().bold();
                 let name = reg_name.bold();
 
-                format!("{} {}{}", message, register_dollar, name)
+                format!("{message} {register_dollar}{name}")
             }
             Error::UnknownInstruction { inst_ast } | Error::InstructionSimName { inst_ast, .. } => {
                 let message = "unknown instruction".bright_red().bold();
                 let inst_name = inst_ast.name().bold();
 
-                format!("{} `{}`", message, inst_name)
+                format!("{message} `{inst_name}`")
             }
 
             Error::InstructionBadFormat { inst_ast, .. } => {
@@ -251,7 +251,7 @@ impl Error {
                     .bold();
                 let inst_name = inst_ast.name().bold();
 
-                format!("{} `{}` {}", message_1, inst_name, message_2)
+                format!("{message_1} `{inst_name}` {message_2}")
             }
 
             Error::RedefinedLabel { label } => {
@@ -259,7 +259,7 @@ impl Error {
                 let message_2 = "is defined multiple times".bright_red().bold();
                 let label = label.bold();
 
-                format!("{} `{}` {}", message_1, label, message_2)
+                format!("{message_1} `{label}` {message_2}")
             }
 
             Error::UnresolvedLabel { label, .. } => {
@@ -267,7 +267,7 @@ impl Error {
                 let message_2 = "in program".bright_red().bold();
                 let label = label.bold();
 
-                format!("{} `{}` {}", message_1, label, message_2)
+                format!("{message_1} `{label}` {message_2}")
             }
 
             Error::RedefinedConstant { label } => {
@@ -275,7 +275,7 @@ impl Error {
                 let message_2 = "is defined multiple times".bright_red().bold();
                 let label = label.bold();
 
-                format!("{} `{}` {}", message_1, label, message_2)
+                format!("{message_1} `{label}` {message_2}")
             }
 
             Error::UnresolvedConstant { label } => {
@@ -283,7 +283,7 @@ impl Error {
                 let message_2 = "in program".bright_red().bold();
                 let label = label.bold();
 
-                format!("{} `{}` {}", message_1, label, message_2)
+                format!("{message_1} `{label}` {message_2}")
             }
 
             Error::ConstantValueDoesNotFit {
@@ -298,18 +298,26 @@ impl Error {
                 let low = range_low.to_string().bold();
                 let high = range_high.to_string().bold();
 
-                format!(
-                    "{} `{}` {} {} {} {}",
-                    message_1, value, message_2, low, message_3, high
-                )
+                format!("{message_1} `{value}` {message_2} {low} {message_3} {high}",)
+            }
+
+            Error::ConstantEvaluationDoesNotFit => {
+                let message_1 = "constant value".bright_red().bold();
+                let message_2 = "must be between".bright_red().bold();
+                let and = "and".bright_red().bold();
+                let low = i64::MIN.to_string().bold();
+                let high = i64::MAX.to_string().bold();
+
+                format!("{message_1} {message_2} {low} {and} {high}",)
             }
 
             Error::DataInTextSegment { directive_type } => {
                 let message_1 = "cannot put".bright_red().bold();
+                let dot = ".".bold();
                 let message_2 = directive_type.to_string().bold();
                 let message_3 = "directive into text segment".bright_red().bold();
 
-                format!("{} `{}{}` {}", message_1, ".".bold(), message_2, message_3)
+                format!("{message_1} `{dot}{message_2}` {message_3}")
             }
 
             Error::InstructionInDataSegment => {
@@ -317,7 +325,7 @@ impl Error {
                     .bright_red()
                     .bold();
 
-                format!("{}", message_1)
+                format!("{message_1}")
             }
 
             Error::TooMuchData { .. } => {
@@ -325,7 +333,7 @@ impl Error {
                 let message_2 = ".data".bold();
                 let message_3 = "segment".bright_red().bold();
 
-                format!("{} `{}` {}", message_1, message_2, message_3)
+                format!("{message_1} `{message_2}` {message_3}")
             }
         }
     }
@@ -505,6 +513,10 @@ impl Error {
                 let tip = format!("required by `{}` directive\n", directive);
 
                 vec![tip]
+            }
+
+            Error::ConstantEvaluationDoesNotFit { .. } => {
+                vec!["try compute less".to_owned()]
             }
 
             Error::DataInTextSegment { directive_type } => {

--- a/crates/mipsy_lib/src/error/compiler/mod.rs
+++ b/crates/mipsy_lib/src/error/compiler/mod.rs
@@ -186,7 +186,9 @@ pub enum Error {
         range_low: i64,
         range_high: i64,
     },
-    ConstantEvaluationDoesNotFit,
+    ConstantExpressionDoesNotFit {
+        eval: String,
+    },
 
     DataInTextSegment {
         directive_type: MpDirective,
@@ -298,17 +300,17 @@ impl Error {
                 let low = range_low.to_string().bold();
                 let high = range_high.to_string().bold();
 
-                format!("{message_1} `{value}` {message_2} {low} {message_3} {high}",)
+                format!("{message_1} `{value}` {message_2} {low} {message_3} {high}")
             }
 
-            Error::ConstantEvaluationDoesNotFit => {
-                let message_1 = "constant value".bright_red().bold();
+            Error::ConstantExpressionDoesNotFit { eval } => {
+                let message_1 = "constant expression".bright_red().bold();
                 let message_2 = "must be between".bright_red().bold();
                 let and = "and".bright_red().bold();
                 let low = i64::MIN.to_string().bold();
-                let high = i64::MAX.to_string().bold();
+                let high = u64::MAX.to_string().bold();
 
-                format!("{message_1} {message_2} {low} {and} {high}",)
+                format!("{message_1} `{eval}` {message_2} {low} {and} {high}")
             }
 
             Error::DataInTextSegment { directive_type } => {
@@ -515,7 +517,7 @@ impl Error {
                 vec![tip]
             }
 
-            Error::ConstantEvaluationDoesNotFit { .. } => {
+            Error::ConstantExpressionDoesNotFit { .. } => {
                 vec!["try compute less".to_owned()]
             }
 

--- a/crates/mipsy_lib/src/error/compiler/mod.rs
+++ b/crates/mipsy_lib/src/error/compiler/mod.rs
@@ -63,10 +63,12 @@ impl CompilerError {
     // TODO(zkol): Can't just pull tab_size from the config, since
     // file may have #![tabsize(...)]
     fn highlight_line(&self, config: &MipsyConfig, file: Rc<str>) {
-        let line = file
-            .lines()
-            .nth((self.line - 1) as usize)
-            .expect("invalid line position in compiler error");
+        let line = file.lines().nth((self.line - 1) as usize);
+        if line.is_none() {
+            return;
+        }
+        let line = line.unwrap();
+        // .expect("invalid line position in compiler error");
 
         let updated_line = {
             let mut updated_line = String::new();

--- a/crates/mipsy_lib/src/error/compiler/mod.rs
+++ b/crates/mipsy_lib/src/error/compiler/mod.rs
@@ -63,12 +63,10 @@ impl CompilerError {
     // TODO(zkol): Can't just pull tab_size from the config, since
     // file may have #![tabsize(...)]
     fn highlight_line(&self, config: &MipsyConfig, file: Rc<str>) {
-        let line = file.lines().nth((self.line - 1) as usize);
-        if line.is_none() {
-            return;
-        }
-        let line = line.unwrap();
-        // .expect("invalid line position in compiler error");
+        let line = file
+            .lines()
+            .nth((self.line - 1) as usize)
+            .expect("invalid line position in compiler error");
 
         let updated_line = {
             let mut updated_line = String::new();

--- a/crates/mipsy_lib/src/error/mod.rs
+++ b/crates/mipsy_lib/src/error/mod.rs
@@ -27,9 +27,9 @@ pub enum InternalError {
     Runtime(runtime::Error),
 }
 
-impl MipsyError {
-    pub fn into_internal_error(&self) -> InternalError {
-        match self {
+impl From<MipsyError> for InternalError {
+    fn from(value: MipsyError) -> InternalError {
+        match value {
             MipsyError::Parser(p) => InternalError::Parser(p.error().clone()),
             MipsyError::Compiler(c) => InternalError::Compiler(c.error().clone()),
             MipsyError::Runtime(r) => InternalError::Runtime(r.error().clone()),

--- a/crates/mipsy_lib/src/error/mod.rs
+++ b/crates/mipsy_lib/src/error/mod.rs
@@ -27,6 +27,16 @@ pub enum InternalError {
     Runtime(runtime::Error),
 }
 
+impl MipsyError {
+    pub fn into_internal_error(&self) -> InternalError {
+        match self {
+            MipsyError::Parser(p) => InternalError::Parser(p.error().clone()),
+            MipsyError::Compiler(c) => InternalError::Compiler(c.error().clone()),
+            MipsyError::Runtime(r) => InternalError::Runtime(r.error().clone()),
+        }
+    }
+}
+
 pub trait ToMipsyResult<T> {
     fn into_parser_mipsy_result(self, file_tag: Rc<str>, line: u32, col: u32) -> MipsyResult<T>;
     fn into_compiler_mipsy_result(
@@ -41,10 +51,7 @@ pub trait ToMipsyResult<T> {
 
 impl<T> ToMipsyResult<T> for MipsyInternalResult<T> {
     fn into_parser_mipsy_result(self, file_tag: Rc<str>, line: u32, col: u32) -> MipsyResult<T> {
-        match self {
-            Ok(t) => Ok(t),
-            Err(error) => Err(error.into_parser_mipsy_error(file_tag, line, col)),
-        }
+        self.map_err(|e| e.into_parser_mipsy_error(file_tag, line, col))
     }
 
     fn into_compiler_mipsy_result(
@@ -54,17 +61,11 @@ impl<T> ToMipsyResult<T> for MipsyInternalResult<T> {
         col: u32,
         col_end: u32,
     ) -> MipsyResult<T> {
-        match self {
-            Ok(t) => Ok(t),
-            Err(error) => Err(error.into_compiler_mipsy_error(file_tag, line, col, col_end)),
-        }
+        self.map_err(|e| e.into_compiler_mipsy_error(file_tag, line, col, col_end))
     }
 
     fn into_runtime_mipsy_result(self) -> MipsyResult<T> {
-        match self {
-            Ok(t) => Ok(t),
-            Err(error) => Err(error.into_runtime_mipsy_error()),
-        }
+        self.map_err(|e| e.into_runtime_mipsy_error())
     }
 }
 

--- a/crates/mipsy_lib/src/inst/instruction.rs
+++ b/crates/mipsy_lib/src/inst/instruction.rs
@@ -3,13 +3,15 @@ use std::{collections::HashMap, fmt, str::FromStr};
 
 use super::register::Register;
 use crate::{
-    compile::data::{eval_constant, eval_value_in_range}, error::{
+    compile::data::{eval_constant, eval_value_in_range},
+    error::{
         compiler::{
             DirectiveType,
             Error::{self, UnresolvedConstant},
         },
         InternalError, MipsyInternalResult,
-    }, Binary, MipsyResult, TEXT_BOT
+    },
+    Binary, MipsyResult, TEXT_BOT,
 };
 use mipsy_parser::{
     parse_argument, MpArgument, MpImmediate, MpInstruction, MpNumber, MpOffsetOperator, MpRegister,
@@ -388,7 +390,8 @@ impl InstSignature {
                             num as u32
                         }
                         MpArgument::Number(MpNumber::Constant(cnst)) => {
-                            eval_constant(program, cnst, "".into()).map_err(InternalError::from)? as u32
+                            eval_constant(program, cnst, "".into()).map_err(InternalError::from)?
+                                as u32
                         }
                         _ => unreachable!(),
                     }
@@ -598,7 +601,7 @@ impl ArgumentType {
                     &MpImmediate::U16(num) => match self {
                         Self::U16 | Self::I32 | Self::U32 | Self::Off32Rs | Self::Off32Rt => true,
                         Self::Shamt => eval_value_in_range(num as _, 0..32).and(Ok(true))?,
-                        _ => false
+                        _ => false,
                     },
                     &MpImmediate::I32(num) => match self {
                         Self::I32 | Self::J | Self::Off32Rs | Self::Off32Rt => true,

--- a/crates/mipsy_lib/src/inst/instruction.rs
+++ b/crates/mipsy_lib/src/inst/instruction.rs
@@ -3,8 +3,13 @@ use std::{collections::HashMap, fmt, str::FromStr};
 
 use super::register::Register;
 use crate::{
-    compile::data::eval_constant,
-    error::{compiler::Error::UnresolvedConstant, InternalError, MipsyInternalResult},
+    compile::data::{eval_constant, eval_value_in_range},
+    error::{
+        compiler::{
+            DirectiveType, Error::{self, UnresolvedConstant}
+        },
+        InternalError, MipsyInternalResult,
+    },
     Binary, TEXT_BOT,
 };
 use mipsy_parser::{
@@ -35,9 +40,12 @@ impl InstSet {
     }
 
     pub fn both_sets(&self) -> Vec<SignatureRef<'_>> {
-        self.native_set.iter().map(SignatureRef::Native).chain(self.pseudo_set.iter().map(SignatureRef::Pseudo)).collect()
+        self.native_set
+            .iter()
+            .map(SignatureRef::Native)
+            .chain(self.pseudo_set.iter().map(SignatureRef::Pseudo))
+            .collect()
     }
-
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -306,12 +314,9 @@ impl InstSet {
         })
     }
 
-    pub fn find_errors(
-        &self,
-        inst: &MpInstruction,
-        program: &Binary,
-    ) -> MipsyInternalResult<()> {
-        self.both_sets().iter()
+    pub fn find_errors(&self, inst: &MpInstruction, program: &Binary) -> MipsyInternalResult<()> {
+        self.both_sets()
+            .iter()
             .filter(|i| inst.name() == i.name())
             .map(|i| match i.compile_sig().matches(inst, program) {
                 Ok(_) => Ok(()),
@@ -579,7 +584,7 @@ impl ArgumentType {
                     &MpImmediate::I16(num) => match self {
                         Self::I16 | Self::I32 | Self::Off32Rs | Self::Off32Rt => true,
                         Self::U16 | Self::U32 => num >= 0,
-                        Self::Shamt => (0..=31).contains(&num),
+                        Self::Shamt => eval_value_in_range(num as _, 0..32).and(Ok(true))?,
                         _ => false,
                     },
                     MpImmediate::U16(_) => matches!(
@@ -614,7 +619,14 @@ impl ArgumentType {
                     .map_err(InternalError::from)
                     .and_then(|c| {
                         self.matches(
-                            &MpArgument::Number(MpNumber::Immediate(c.into())),
+                            &MpArgument::Number(MpNumber::Immediate(c.try_into().or(Err(InternalError::Compiler(
+                                Error::ConstantValueDoesNotFit {
+                                    directive_type: DirectiveType::Byte,
+                                    value: c,
+                                    range_low: i32::MIN as _,
+                                    range_high: i32::MAX as _,
+                                },
+                            )))?)),
                             relative_label,
                             program,
                         )

--- a/crates/mipsy_lib/src/inst/instruction.rs
+++ b/crates/mipsy_lib/src/inst/instruction.rs
@@ -462,6 +462,9 @@ impl InstSignature {
                             }
                             _ => unreachable!(),
                         },
+                        MpNumber::Constant(cnst) => eval_constant(program, cnst, "".into())
+                            .map_err(InternalError::from)?
+                            as i32 as u32,
                         _ => unreachable!(),
                     },
                     _ => unreachable!(),
@@ -529,9 +532,9 @@ impl CompileSignature {
             // labels are only relative as the final argument
             let relative_label = (i == args.len() - 1) && self.relative_label;
             match my_arg.matches(their_arg, relative_label, program) {
+                Ok(true) => {}
                 Ok(false) => return Ok(false),
                 Err(e) => return Err(e),
-                _ => {}
             }
         }
 
@@ -618,27 +621,30 @@ impl ArgumentType {
                     },
                 },
                 MpNumber::Constant(cnst) => eval_constant(program, cnst, "".into())
-                    // skip over the unresolved constant error here
+                    .map_err(InternalError::from)
+                    .and_then(|v| {
+                        v.try_into().or(Err(InternalError::Compiler(
+                            Error::ConstantValueDoesNotFit {
+                                directive_type: DirectiveType::Byte,
+                                value: v,
+                                range_low: i32::MIN as _,
+                                range_high: u32::MAX as _,
+                            },
+                        )))
+                    })
+                    // skip over the unrsolved constant error here
                     // since immediate constants wouldnt be defined
                     .or_else(|e| {
-                        if matches!(&e, crate::MipsyError::Compiler(c)
-                            if matches!(c.error(), UnresolvedConstant { .. }))
-                        {
-                            return Ok(0);
-                        }
-                        return Err(e);
+                        matches!(&e, InternalError::Compiler(UnresolvedConstant { .. }))
+                            .then_some(match self {
+                                Self::J => MpImmediate::U32(0),
+                                _ => MpImmediate::U16(0),
+                            })
+                            .ok_or(e)
                     })
-                    .map_err(InternalError::from)
-                    .and_then(|c| {
+                    .and_then(|i| {
                         self.matches(
-                            &MpArgument::Number(MpNumber::Immediate(c.try_into().or(Err(
-                                InternalError::Compiler(Error::ConstantValueDoesNotFit {
-                                    directive_type: DirectiveType::Byte,
-                                    value: c,
-                                    range_low: i32::MIN as _,
-                                    range_high: i32::MAX as _,
-                                }),
-                            ))?)),
+                            &MpArgument::Number(MpNumber::Immediate(i)),
                             relative_label,
                             program,
                         )

--- a/crates/mipsy_lib/src/inst/instruction.rs
+++ b/crates/mipsy_lib/src/inst/instruction.rs
@@ -3,14 +3,13 @@ use std::{collections::HashMap, fmt, str::FromStr};
 
 use super::register::Register;
 use crate::{
-    compile::data::{eval_constant, eval_value_in_range},
-    error::{
+    compile::data::{eval_constant, eval_value_in_range}, error::{
         compiler::{
-            DirectiveType, Error::{self, UnresolvedConstant}
+            DirectiveType,
+            Error::{self, UnresolvedConstant},
         },
         InternalError, MipsyInternalResult,
-    },
-    Binary, TEXT_BOT,
+    }, Binary, MipsyResult, TEXT_BOT
 };
 use mipsy_parser::{
     parse_argument, MpArgument, MpImmediate, MpInstruction, MpNumber, MpOffsetOperator, MpRegister,
@@ -380,12 +379,20 @@ impl InstSignature {
                     MpArgument::Register(MpRegister::Normal(reg)) => reg.to_register()?.to_u32(),
                     _ => unreachable!(),
                 },
-                ArgumentType::Shamt => match arg {
-                    MpArgument::Number(MpNumber::Immediate(MpImmediate::I16(num))) => {
-                        (*num as u16 as u32) & 0x1F
+                ArgumentType::Shamt => {
+                    0x1F & match arg {
+                        &MpArgument::Number(MpNumber::Immediate(MpImmediate::I16(num))) => {
+                            num as u16 as u32
+                        }
+                        &MpArgument::Number(MpNumber::Immediate(MpImmediate::U16(num))) => {
+                            num as u32
+                        }
+                        MpArgument::Number(MpNumber::Constant(cnst)) => {
+                            eval_constant(program, cnst, "".into()).map_err(InternalError::from)? as u32
+                        }
+                        _ => unreachable!(),
                     }
-                    _ => unreachable!(),
-                },
+                }
                 ArgumentType::I16 => match arg {
                     MpArgument::Number(num) => match num {
                         MpNumber::Immediate(imm) => match imm {
@@ -585,12 +592,14 @@ impl ArgumentType {
                         Self::I16 | Self::I32 | Self::Off32Rs | Self::Off32Rt => true,
                         Self::U16 | Self::U32 => num >= 0,
                         Self::Shamt => eval_value_in_range(num as _, 0..32).and(Ok(true))?,
+                        // Self::Shamt => eval_value_in_range(num as _, 0..32).into_compiler_mipsy_result("".into(), line, col, col_end).and(Ok(true))?,
                         _ => false,
                     },
-                    MpImmediate::U16(_) => matches!(
-                        self,
-                        Self::U16 | Self::I32 | Self::U32 | Self::Off32Rs | Self::Off32Rt
-                    ),
+                    &MpImmediate::U16(num) => match self {
+                        Self::U16 | Self::I32 | Self::U32 | Self::Off32Rs | Self::Off32Rt => true,
+                        Self::Shamt => eval_value_in_range(num as _, 0..32).and(Ok(true))?,
+                        _ => false
+                    },
                     &MpImmediate::I32(num) => match self {
                         Self::I32 | Self::J | Self::Off32Rs | Self::Off32Rt => true,
                         Self::U32 => num >= 0,
@@ -609,24 +618,24 @@ impl ArgumentType {
                     // skip over the unresolved constant error here
                     // since immediate constants wouldnt be defined
                     .or_else(|e| {
-                        if let crate::MipsyError::Compiler(c) = &e {
-                            if matches!(c.error(), UnresolvedConstant { .. }) {
-                                return Ok(0);
-                            }
+                        if matches!(&e, crate::MipsyError::Compiler(c)
+                            if matches!(c.error(), UnresolvedConstant { .. }))
+                        {
+                            return Ok(0);
                         }
                         return Err(e);
                     })
                     .map_err(InternalError::from)
                     .and_then(|c| {
                         self.matches(
-                            &MpArgument::Number(MpNumber::Immediate(c.try_into().or(Err(InternalError::Compiler(
-                                Error::ConstantValueDoesNotFit {
+                            &MpArgument::Number(MpNumber::Immediate(c.try_into().or(Err(
+                                InternalError::Compiler(Error::ConstantValueDoesNotFit {
                                     directive_type: DirectiveType::Byte,
                                     value: c,
                                     range_low: i32::MIN as _,
                                     range_high: i32::MAX as _,
-                                },
-                            )))?)),
+                                }),
+                            ))?)),
                             relative_label,
                             program,
                         )

--- a/crates/mipsy_lib/src/inst/instruction.rs
+++ b/crates/mipsy_lib/src/inst/instruction.rs
@@ -33,6 +33,11 @@ impl InstSet {
     pub fn pseudo_set(&self) -> &[PseudoSignature] {
         &self.pseudo_set
     }
+
+    pub fn both_sets(&self) -> Vec<SignatureRef<'_>> {
+        self.native_set.iter().map(SignatureRef::Native).chain(self.pseudo_set.iter().map(SignatureRef::Pseudo)).collect()
+    }
+
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -287,7 +292,8 @@ impl InstSet {
         let name = inst.name().to_ascii_lowercase();
 
         self.native_set.iter().find(|&native_inst| {
-            native_inst.name == name && native_inst.compile.matches(inst, program)
+            native_inst.name == name
+                && matches!(native_inst.compile.matches(inst, program), Ok(true))
         })
     }
 
@@ -295,8 +301,24 @@ impl InstSet {
         let name = inst.name().to_ascii_lowercase();
 
         self.pseudo_set.iter().find(|&pseudo_inst| {
-            pseudo_inst.name == name && pseudo_inst.compile.matches(inst, program)
+            pseudo_inst.name == name
+                && matches!(pseudo_inst.compile.matches(inst, program), Ok(true))
         })
+    }
+
+    pub fn find_errors(
+        &self,
+        inst: &MpInstruction,
+        program: &Binary,
+    ) -> MipsyInternalResult<()> {
+        self.both_sets().iter()
+            .filter(|i| inst.name() == i.name())
+            .map(|i| match i.compile_sig().matches(inst, program) {
+                Ok(_) => Ok(()),
+                Err(e) => Err(e),
+            })
+            .find(Result::is_err)
+            .unwrap_or(Ok(()))
     }
 }
 
@@ -472,27 +494,33 @@ impl InstSignature {
 }
 
 impl CompileSignature {
-    pub fn matches(&self, inst: &MpInstruction, program: &Binary) -> bool {
+    pub fn matches(&self, inst: &MpInstruction, program: &Binary) -> MipsyInternalResult<bool> {
         self.matches_args(
             inst.arguments().iter().map(|(arg, _, _)| arg).collect(),
             program,
         )
     }
 
-    pub fn matches_args(&self, args: Vec<&MpArgument>, program: &Binary) -> bool {
+    pub fn matches_args(
+        &self,
+        args: Vec<&MpArgument>,
+        program: &Binary,
+    ) -> MipsyInternalResult<bool> {
         if self.format.len() != args.len() {
-            return false;
+            return Ok(false);
         }
 
         for (i, (my_arg, &their_arg)) in self.format.iter().zip(args.iter()).enumerate() {
             // labels are only relative as the final argument
             let relative_label = (i == args.len() - 1) && self.relative_label;
-            if !my_arg.matches(their_arg, relative_label, program) {
-                return false;
+            match my_arg.matches(their_arg, relative_label, program) {
+                Ok(false) => return Ok(false),
+                Err(e) => return Err(e),
+                _ => {}
             }
         }
 
-        true
+        Ok(true)
     }
 }
 
@@ -519,8 +547,16 @@ impl fmt::Display for ArgumentType {
 }
 
 impl ArgumentType {
-    fn matches(&self, arg: &MpArgument, relative_label: bool, program: &Binary) -> bool {
-        match arg {
+    /// Ok(true) => no special error & found  a match
+    /// Ok(false)=> no special error & found no match
+    /// Err      =>  a special error & found no match
+    fn matches(
+        &self,
+        arg: &MpArgument,
+        relative_label: bool,
+        program: &Binary,
+    ) -> MipsyInternalResult<bool> {
+        Ok(match arg {
             MpArgument::Register(register) => match register {
                 MpRegister::Normal(_) => matches!(self, Self::Rd | Self::Rs | Self::Rt),
                 MpRegister::Offset(imm, _) => match imm {
@@ -565,31 +601,31 @@ impl ArgumentType {
                     },
                 },
                 MpNumber::Constant(cnst) => eval_constant(program, cnst, "".into())
+                    // skip over the unresolved constant error here
+                    // since immediate constants wouldnt be defined
                     .or_else(|e| {
                         if let crate::MipsyError::Compiler(c) = &e {
                             if matches!(c.error(), UnresolvedConstant { .. }) {
-                                Ok(0)
-                            } else {
-                                Err(e)
+                                return Ok(0);
                             }
-                        } else {
-                            Err(e)
                         }
+                        return Err(e);
                     })
-                    .is_ok_and(|c| {
+                    .map_err(InternalError::from)
+                    .and_then(|c| {
                         self.matches(
                             &MpArgument::Number(MpNumber::Immediate(c.into())),
                             relative_label,
                             program,
                         )
-                    }),
+                    })?,
                 MpNumber::Char(_) => {
                     matches!(self, Self::I16 | Self::I32 | Self::U16 | Self::U32)
                 }
                 MpNumber::Float32(_) => matches!(self, Self::F32 | Self::F64),
                 MpNumber::Float64(_) => matches!(self, Self::F64),
             },
-        }
+        })
     }
 }
 

--- a/crates/mipsy_lib/src/inst/instruction.rs
+++ b/crates/mipsy_lib/src/inst/instruction.rs
@@ -2,7 +2,10 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt, str::FromStr};
 
 use super::register::Register;
-use crate::{compile::data::eval_constant, error::MipsyInternalResult, Binary, TEXT_BOT};
+use crate::{
+    compile::data::eval_constant, error::compiler::Error::UnresolvedConstant,
+    error::MipsyInternalResult, Binary, TEXT_BOT,
+};
 use mipsy_parser::{
     parse_argument, MpArgument, MpImmediate, MpInstruction, MpNumber, MpOffsetOperator, MpRegister,
     MpRegisterIdentifier,
@@ -560,20 +563,31 @@ impl ArgumentType {
                         _ => false,
                     },
                 },
-                MpNumber::Constant(cnst) => match eval_constant(program, cnst, "".into()) {
-                    Ok(c) => self.matches(
-                        &MpArgument::Number(MpNumber::Immediate(c.into())),
-                        relative_label,
-                        program,
-                    ),
-                    Err(_) => false,
-                },
+                MpNumber::Constant(cnst) => eval_constant(program, cnst, "".into())
+                    .or_else(|e| {
+                        if let crate::MipsyError::Compiler(c) = &e {
+                            if matches!(c.error(), UnresolvedConstant { .. }) {
+                                Ok(0)
+                            } else {
+                                Err(e)
+                            }
+                        } else {
+                            Err(e)
+                        }
+                    })
+                    .is_ok_and(|c| {
+                        self.matches(
+                            &MpArgument::Number(MpNumber::Immediate(c.into())),
+                            relative_label,
+                            program,
+                        )
+                    }),
                 MpNumber::Char(_) => {
                     matches!(self, Self::I16 | Self::I32 | Self::U16 | Self::U32)
                 }
                 MpNumber::Float32(_) => matches!(self, Self::F32 | Self::F64),
                 MpNumber::Float64(_) => matches!(self, Self::F64),
-            }, // MpArgument::LabelPlusConst(..)
+            },
         }
     }
 }

--- a/crates/mipsy_lib/src/inst/instruction.rs
+++ b/crates/mipsy_lib/src/inst/instruction.rs
@@ -2,9 +2,9 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt, str::FromStr};
 
 use super::register::Register;
-use crate::{error::MipsyInternalResult, Binary, TEXT_BOT};
+use crate::{error::MipsyInternalResult, Binary, TEXT_BOT, compile::data::eval_constant};
 use mipsy_parser::{
-    parse_argument, MpArgument, MpImmediate, MpImmediateBinaryOp, MpInstruction, MpNumber,
+    parse_argument, MpArgument, MpImmediate, MpInstruction, MpNumber,
     MpOffsetOperator, MpRegister, MpRegisterIdentifier,
 };
 
@@ -374,6 +374,7 @@ impl InstSignature {
                             }
                             _ => unreachable!(),
                         },
+                        MpNumber::Constant(cnst) => eval_constant(program, cnst, "hi".into()).unwrap() as u32,
                         &MpNumber::Char(chr) => chr as u8 as u32,
                         _ => unreachable!(),
                     },
@@ -398,6 +399,7 @@ impl InstSignature {
                             }
                             _ => unreachable!(),
                         },
+                        MpNumber::Constant(cnst) => eval_constant(program, cnst, "hi".into()).unwrap() as u64 as u32,
                         &MpNumber::Char(chr) => chr as u8 as u32,
                         _ => unreachable!(),
                     },
@@ -552,9 +554,10 @@ impl ArgumentType {
                             _ => false,
                         },
                     },
-                    MpNumber::BinaryOpImmediate(_imm1, _op, _imm2) => {
-                        // TODO(zkol): this is brittle and based on faulty assumptions
-                        matches!(self, Self::I32 | Self::U32 | Self::Off32Rs | Self::Off32Rt)
+                    MpNumber::Constant(cnst) => {
+                        // self.matches(csnt, relative_label)
+                        // self.matches(csnt, relative_label)
+                        true
                     }
                     MpNumber::Char(_) => {
                         matches!(self, Self::I16 | Self::I32 | Self::U16 | Self::U32)
@@ -699,27 +702,9 @@ impl PseudoSignature {
                     }
                 },
                 &MpNumber::Char(chr) => (chr as u16, 0_u16),
-                MpNumber::BinaryOpImmediate(imm1, op, imm2) => {
-                    let (lower1, upper1) = self.lower_upper(
-                        program,
-                        &MpArgument::Number(MpNumber::Immediate(imm1.clone())),
-                        last,
-                    )?;
-                    let (lower2, upper2) = self.lower_upper(
-                        program,
-                        &MpArgument::Number(MpNumber::Immediate(imm2.clone())),
-                        last,
-                    )?;
-
-                    let i1 = (((upper1 as u32) << 16) | lower1 as u32) as i32;
-                    let i2 = (((upper2 as u32) << 16) | lower2 as u32) as i32;
-
-                    let value = match op {
-                        MpImmediateBinaryOp::Plus => i1.wrapping_add(i2),
-                        MpImmediateBinaryOp::Minus => i1.wrapping_sub(i2),
-                    } as u32;
-
-                    ((value & 0xFFFF) as u16, (value >> 16) as u16)
+                MpNumber::Constant(cnst) => {
+                    let val = eval_constant(program, cnst, "hi".into()).unwrap();
+                    ((val as u16 & 0xFFFF) as u16, (val >> 16) as u16)
                 }
                 _ => unreachable!(),
             },

--- a/crates/mipsy_lib/src/inst/instruction.rs
+++ b/crates/mipsy_lib/src/inst/instruction.rs
@@ -2,10 +2,10 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt, str::FromStr};
 
 use super::register::Register;
-use crate::{error::MipsyInternalResult, Binary, TEXT_BOT, compile::data::eval_constant};
+use crate::{compile::data::eval_constant, error::MipsyInternalResult, Binary, TEXT_BOT};
 use mipsy_parser::{
-    parse_argument, MpArgument, MpImmediate, MpInstruction, MpNumber,
-    MpOffsetOperator, MpRegister, MpRegisterIdentifier,
+    parse_argument, MpArgument, MpImmediate, MpInstruction, MpNumber, MpOffsetOperator, MpRegister,
+    MpRegisterIdentifier,
 };
 
 #[derive(Debug, Clone)]
@@ -279,20 +279,20 @@ impl InstSet {
             .find(|&native_inst| native_inst.name == name)
     }
 
-    pub fn find_native(&self, inst: &MpInstruction) -> Option<&InstSignature> {
+    pub fn find_native(&self, inst: &MpInstruction, program: &Binary) -> Option<&InstSignature> {
         let name = inst.name().to_ascii_lowercase();
 
-        self.native_set
-            .iter()
-            .find(|&native_inst| native_inst.name == name && native_inst.compile.matches(inst))
+        self.native_set.iter().find(|&native_inst| {
+            native_inst.name == name && native_inst.compile.matches(inst, program)
+        })
     }
 
-    pub fn find_pseudo(&self, inst: &MpInstruction) -> Option<&PseudoSignature> {
+    pub fn find_pseudo(&self, inst: &MpInstruction, program: &Binary) -> Option<&PseudoSignature> {
         let name = inst.name().to_ascii_lowercase();
 
-        self.pseudo_set
-            .iter()
-            .find(|&pseudo_inst| pseudo_inst.name == name && pseudo_inst.compile.matches(inst))
+        self.pseudo_set.iter().find(|&pseudo_inst| {
+            pseudo_inst.name == name && pseudo_inst.compile.matches(inst, program)
+        })
     }
 }
 
@@ -374,7 +374,9 @@ impl InstSignature {
                             }
                             _ => unreachable!(),
                         },
-                        MpNumber::Constant(cnst) => eval_constant(program, cnst, "hi".into()).unwrap() as u32,
+                        MpNumber::Constant(cnst) => eval_constant(program, cnst, "".into())
+                            .map_err(|e| e.into_internal_error())?
+                            as u32,
                         &MpNumber::Char(chr) => chr as u8 as u32,
                         _ => unreachable!(),
                     },
@@ -399,7 +401,9 @@ impl InstSignature {
                             }
                             _ => unreachable!(),
                         },
-                        MpNumber::Constant(cnst) => eval_constant(program, cnst, "hi".into()).unwrap() as u64 as u32,
+                        MpNumber::Constant(cnst) => eval_constant(program, cnst, "".into())
+                            .map_err(|e| e.into_internal_error())?
+                            as u64 as u32,
                         &MpNumber::Char(chr) => chr as u8 as u32,
                         _ => unreachable!(),
                     },
@@ -464,11 +468,14 @@ impl InstSignature {
 }
 
 impl CompileSignature {
-    pub fn matches(&self, inst: &MpInstruction) -> bool {
-        self.matches_args(inst.arguments().iter().map(|(arg, _, _)| arg).collect())
+    pub fn matches(&self, inst: &MpInstruction, program: &Binary) -> bool {
+        self.matches_args(
+            inst.arguments().iter().map(|(arg, _, _)| arg).collect(),
+            program,
+        )
     }
 
-    pub fn matches_args(&self, args: Vec<&MpArgument>) -> bool {
+    pub fn matches_args(&self, args: Vec<&MpArgument>, program: &Binary) -> bool {
         if self.format.len() != args.len() {
             return false;
         }
@@ -476,7 +483,7 @@ impl CompileSignature {
         for (i, (my_arg, &their_arg)) in self.format.iter().zip(args.iter()).enumerate() {
             // labels are only relative as the final argument
             let relative_label = (i == args.len() - 1) && self.relative_label;
-            if !my_arg.matches(their_arg, relative_label) {
+            if !my_arg.matches(their_arg, relative_label, program) {
                 return false;
             }
         }
@@ -508,7 +515,7 @@ impl fmt::Display for ArgumentType {
 }
 
 impl ArgumentType {
-    fn matches(&self, arg: &MpArgument, relative_label: bool) -> bool {
+    fn matches(&self, arg: &MpArgument, relative_label: bool, program: &Binary) -> bool {
         match arg {
             MpArgument::Register(register) => match register {
                 MpRegister::Normal(_) => matches!(self, Self::Rd | Self::Rs | Self::Rt),
@@ -527,45 +534,46 @@ impl ArgumentType {
                 },
                 MpRegister::BinaryOpOffset(..) => matches!(self, Self::Off32Rs | Self::Off32Rt),
             },
-            MpArgument::Number(number) => {
-                match number {
-                    MpNumber::Immediate(immediate) => match immediate {
-                        &MpImmediate::I16(num) => match self {
-                            Self::I16 | Self::I32 | Self::Off32Rs | Self::Off32Rt => true,
-                            Self::U16 | Self::U32 => num >= 0,
-                            Self::Shamt => (0..=31).contains(&num),
-                            _ => false,
-                        },
-                        MpImmediate::U16(_) => matches!(
-                            self,
-                            Self::U16 | Self::I32 | Self::U32 | Self::Off32Rs | Self::Off32Rt
-                        ),
-                        &MpImmediate::I32(num) => match self {
-                            Self::I32 | Self::J | Self::Off32Rs | Self::Off32Rt => true,
-                            Self::U32 => num >= 0,
-                            _ => false,
-                        },
-                        MpImmediate::U32(_) => {
-                            matches!(self, Self::J | Self::U32 | Self::Off32Rs | Self::Off32Rt)
-                        }
-                        MpImmediate::LabelReference(_) => match self {
-                            Self::I32 | Self::U32 | Self::J | Self::Off32Rs | Self::Off32Rt => true,
-                            Self::I16 => relative_label,
-                            _ => false,
-                        },
+            MpArgument::Number(number) => match number {
+                MpNumber::Immediate(immediate) => match immediate {
+                    &MpImmediate::I16(num) => match self {
+                        Self::I16 | Self::I32 | Self::Off32Rs | Self::Off32Rt => true,
+                        Self::U16 | Self::U32 => num >= 0,
+                        Self::Shamt => (0..=31).contains(&num),
+                        _ => false,
                     },
-                    MpNumber::Constant(cnst) => {
-                        // self.matches(csnt, relative_label)
-                        // self.matches(csnt, relative_label)
-                        true
+                    MpImmediate::U16(_) => matches!(
+                        self,
+                        Self::U16 | Self::I32 | Self::U32 | Self::Off32Rs | Self::Off32Rt
+                    ),
+                    &MpImmediate::I32(num) => match self {
+                        Self::I32 | Self::J | Self::Off32Rs | Self::Off32Rt => true,
+                        Self::U32 => num >= 0,
+                        _ => false,
+                    },
+                    MpImmediate::U32(_) => {
+                        matches!(self, Self::J | Self::U32 | Self::Off32Rs | Self::Off32Rt)
                     }
-                    MpNumber::Char(_) => {
-                        matches!(self, Self::I16 | Self::I32 | Self::U16 | Self::U32)
-                    }
-                    MpNumber::Float32(_) => matches!(self, Self::F32 | Self::F64),
-                    MpNumber::Float64(_) => matches!(self, Self::F64),
+                    MpImmediate::LabelReference(_) => match self {
+                        Self::I32 | Self::U32 | Self::J | Self::Off32Rs | Self::Off32Rt => true,
+                        Self::I16 => relative_label,
+                        _ => false,
+                    },
+                },
+                MpNumber::Constant(cnst) => match eval_constant(program, cnst, "".into()) {
+                    Ok(c) => self.matches(
+                        &MpArgument::Number(MpNumber::Immediate(c.into())),
+                        relative_label,
+                        program,
+                    ),
+                    Err(_) => false,
+                },
+                MpNumber::Char(_) => {
+                    matches!(self, Self::I16 | Self::I32 | Self::U16 | Self::U32)
                 }
-            } // MpArgument::LabelPlusConst(..)
+                MpNumber::Float32(_) => matches!(self, Self::F32 | Self::F64),
+                MpNumber::Float64(_) => matches!(self, Self::F64),
+            }, // MpArgument::LabelPlusConst(..)
         }
     }
 }
@@ -703,7 +711,7 @@ impl PseudoSignature {
                 },
                 &MpNumber::Char(chr) => (chr as u16, 0_u16),
                 MpNumber::Constant(cnst) => {
-                    let val = eval_constant(program, cnst, "hi".into()).unwrap();
+                    let val = eval_constant(program, cnst, "".into()).unwrap();
                     ((val as u16 & 0xFFFF) as u16, (val >> 16) as u16)
                 }
                 _ => unreachable!(),

--- a/crates/mipsy_lib/src/inst/instruction.rs
+++ b/crates/mipsy_lib/src/inst/instruction.rs
@@ -3,8 +3,9 @@ use std::{collections::HashMap, fmt, str::FromStr};
 
 use super::register::Register;
 use crate::{
-    compile::data::eval_constant, error::compiler::Error::UnresolvedConstant,
-    error::MipsyInternalResult, Binary, TEXT_BOT,
+    compile::data::eval_constant,
+    error::{compiler::Error::UnresolvedConstant, InternalError, MipsyInternalResult},
+    Binary, TEXT_BOT,
 };
 use mipsy_parser::{
     parse_argument, MpArgument, MpImmediate, MpInstruction, MpNumber, MpOffsetOperator, MpRegister,
@@ -378,7 +379,7 @@ impl InstSignature {
                             _ => unreachable!(),
                         },
                         MpNumber::Constant(cnst) => eval_constant(program, cnst, "".into())
-                            .map_err(|e| e.into_internal_error())?
+                            .map_err(InternalError::from)?
                             as u32,
                         &MpNumber::Char(chr) => chr as u8 as u32,
                         _ => unreachable!(),
@@ -405,7 +406,7 @@ impl InstSignature {
                             _ => unreachable!(),
                         },
                         MpNumber::Constant(cnst) => eval_constant(program, cnst, "".into())
-                            .map_err(|e| e.into_internal_error())?
+                            .map_err(InternalError::from)?
                             as u64 as u32,
                         &MpNumber::Char(chr) => chr as u8 as u32,
                         _ => unreachable!(),
@@ -725,8 +726,9 @@ impl PseudoSignature {
                 },
                 &MpNumber::Char(chr) => (chr as u16, 0_u16),
                 MpNumber::Constant(cnst) => {
-                    let val = eval_constant(program, cnst, "".into()).unwrap();
-                    ((val as u16 & 0xFFFF) as u16, (val >> 16) as u16)
+                    let val =
+                        eval_constant(program, cnst, "".into()).map_err(InternalError::from)?;
+                    ((val & 0xFFFF) as u16, (val >> 16) as u16)
                 }
                 _ => unreachable!(),
             },

--- a/crates/mipsy_parser/Cargo.toml
+++ b/crates/mipsy_parser/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-quote = "1.0"
-proc-macro2 = "1.0"
 nom = "7" # parser
 nom_locate = "4"
 serde = { version = "1.0", features = ["derive"] }
+paste = "1.0.15"

--- a/crates/mipsy_parser/Cargo.toml
+++ b/crates/mipsy_parser/Cargo.toml
@@ -9,5 +9,5 @@ edition = "2021"
 [dependencies]
 nom = "7" # parser
 nom_locate = "4"
-serde = { version = "1.0", features = ["derive"] }
 paste = "1.0.15"
+serde = { version = "1.0", features = ["derive"] }

--- a/crates/mipsy_parser/Cargo.toml
+++ b/crates/mipsy_parser/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+quote = "1.0"
+proc-macro2 = "1.0"
 nom = "7" # parser
 nom_locate = "4"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/mipsy_parser/src/lib.rs
+++ b/crates/mipsy_parser/src/lib.rs
@@ -10,7 +10,7 @@ pub use constant::{MpConst, MpConstValue, MpConstValueLoc};
 pub use directive::MpDirective;
 pub use instruction::{MpArgument, MpInstruction};
 pub use misc::{tabs_to_spaces, ErrorLocation};
-pub use number::{MpImmediate, MpImmediateBinaryOp, MpNumber};
+pub use number::{MpImmediate, MpNumber};
 pub use parser::{MpItem, MpProgram, TaggedFile};
 pub use register::{MpOffsetOperator, MpRegister, MpRegisterIdentifier};
 

--- a/crates/mipsy_parser/src/number.rs
+++ b/crates/mipsy_parser/src/number.rs
@@ -1,13 +1,12 @@
 use std::fmt;
 
 use crate::{
-    misc::{escape_char, parse_escaped_char, parse_ident},
-    Span,
+    constant::parse_constant_value, misc::{escape_char, parse_escaped_char, parse_ident}, MpConstValueLoc, Span
 };
 use nom::{
     branch::alt,
     bytes::complete::{is_a, tag},
-    character::complete::{char, digit1, hex_digit1, oct_digit1, one_of, space0},
+    character::complete::{char, digit1, hex_digit1, oct_digit1},
     combinator::{map, map_res, opt},
     number::complete::{double, float},
     sequence::tuple,
@@ -18,7 +17,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum MpNumber {
     Immediate(MpImmediate),
-    BinaryOpImmediate(MpImmediate, MpImmediateBinaryOp, MpImmediate),
+    Constant(MpConstValueLoc),
     Float32(f32),
     Float64(f64),
     Char(char),
@@ -32,18 +31,11 @@ pub enum MpImmediate {
     U32(u32),
     LabelReference(String),
 }
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub enum MpImmediateBinaryOp {
-    Plus,
-    Minus,
-}
-
 impl fmt::Display for MpNumber {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Immediate(imm) => write!(f, "{}", imm),
-            Self::BinaryOpImmediate(i1, op, i2) => write!(f, "{} {} {}", i1, op, i2),
+            Self::Constant(expr) => write!(f, "{}", expr.0),
             Self::Float32(float) => write!(f, "{}", float),
             Self::Float64(float) => write!(f, "{}", float),
             Self::Char(char) => write!(f, "'{}'", escape_char(*char)),
@@ -63,39 +55,14 @@ impl fmt::Display for MpImmediate {
     }
 }
 
-impl fmt::Display for MpImmediateBinaryOp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Plus => write!(f, "+"),
-            Self::Minus => write!(f, "-"),
-        }
-    }
-}
-
 pub fn parse_number(i: Span<'_>) -> IResult<Span<'_>, MpNumber> {
     alt((
-        parse_binary_op_immedaite,
+        map(parse_constant_value, MpNumber::Constant),
         map(parse_immediate, MpNumber::Immediate),
         map(parse_f32, MpNumber::Float32),
         map(parse_f64, MpNumber::Float64),
         map(parse_char, MpNumber::Char),
     ))(i)
-}
-
-pub fn parse_binary_op_immedaite(i: Span<'_>) -> IResult<Span<'_>, MpNumber> {
-    let (remaining_data, (i1, _, op, _, i2)) = tuple((
-        parse_immediate,
-        space0,
-        map(one_of("+-"), |op| match op {
-            '+' => MpImmediateBinaryOp::Plus,
-            '-' => MpImmediateBinaryOp::Minus,
-            _ => unreachable!(),
-        }),
-        space0,
-        parse_immediate,
-    ))(i)?;
-
-    Ok((remaining_data, MpNumber::BinaryOpImmediate(i1, op, i2)))
 }
 
 pub fn parse_immediate(i: Span<'_>) -> IResult<Span<'_>, MpImmediate> {

--- a/crates/mipsy_parser/src/number.rs
+++ b/crates/mipsy_parser/src/number.rs
@@ -62,19 +62,20 @@ macro_rules! immediate_in_range {
     ($n:ident, $($ty:ty),* $(,)?) => {
         if false { unreachable!() }
         $(else if (<$ty>::MIN as i64..=<$ty>::MAX as i64).contains(&$n) {
-            paste::paste!{
+            Some(paste::paste!{
                 MpImmediate::[<$ty:camel>]($n as _)
-            }
+            })
         })*
         else {
-            unimplemented!()
+            None
         }
     }
 }
 
-impl From<i64> for MpImmediate {
-    fn from(n: i64) -> Self {
-        immediate_in_range!(n, u16, i16, u32, i32)
+impl TryFrom<i64> for MpImmediate {
+    type Error = ();
+    fn try_from(n: i64) -> Result<Self, Self::Error> {
+        immediate_in_range!(n, u16, i16, u32, i32).ok_or(())
     }
 }
 

--- a/crates/mipsy_parser/src/number.rs
+++ b/crates/mipsy_parser/src/number.rs
@@ -1,7 +1,9 @@
 use std::fmt;
 
 use crate::{
-    constant::parse_constant_value, misc::{escape_char, parse_escaped_char, parse_ident}, MpConstValueLoc, Span
+    constant::parse_constant_value,
+    misc::{escape_char, parse_escaped_char, parse_ident},
+    MpConstValueLoc, Span,
 };
 use nom::{
     branch::alt,
@@ -31,6 +33,7 @@ pub enum MpImmediate {
     U32(u32),
     LabelReference(String),
 }
+
 impl fmt::Display for MpNumber {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -51,6 +54,23 @@ impl fmt::Display for MpImmediate {
             Self::I32(i) => write!(f, "{}", i),
             Self::U32(i) => write!(f, "{}", i),
             Self::LabelReference(label) => write!(f, "{}", label),
+        }
+    }
+}
+
+impl From<i64> for MpImmediate {
+    fn from(n: i64) -> Self {
+        // immediate_in_range!(n, u16, i16, u32, i32)
+        if (u16::MIN as i64..=u16::MAX as i64).contains(&n) {
+            MpImmediate::U16(n as _)
+        } else if (i16::MIN as i64..=i16::MAX as i64).contains(&n) {
+            MpImmediate::I16(n as _)
+        } else if (u32::MIN as i64..=u32::MAX as i64).contains(&n) {
+            MpImmediate::U32(n as _)
+        } else if (i32::MIN as i64..=i32::MAX as i64).contains(&n) {
+            MpImmediate::I32(n as _)
+        } else {
+            todo!()
         }
     }
 }

--- a/crates/mipsy_parser/src/number.rs
+++ b/crates/mipsy_parser/src/number.rs
@@ -58,20 +58,23 @@ impl fmt::Display for MpImmediate {
     }
 }
 
+macro_rules! immediate_in_range {
+    ($n:ident, $($ty:ty),* $(,)?) => {
+        if false { unreachable!() }
+        $(else if (<$ty>::MIN as i64..=<$ty>::MAX as i64).contains(&$n) {
+            paste::paste!{
+                MpImmediate::[<$ty:camel>]($n as _)
+            }
+        })*
+        else {
+            unimplemented!()
+        }
+    }
+}
+
 impl From<i64> for MpImmediate {
     fn from(n: i64) -> Self {
-        // immediate_in_range!(n, u16, i16, u32, i32)
-        if (u16::MIN as i64..=u16::MAX as i64).contains(&n) {
-            MpImmediate::U16(n as _)
-        } else if (i16::MIN as i64..=i16::MAX as i64).contains(&n) {
-            MpImmediate::I16(n as _)
-        } else if (u32::MIN as i64..=u32::MAX as i64).contains(&n) {
-            MpImmediate::U32(n as _)
-        } else if (i32::MIN as i64..=i32::MAX as i64).contains(&n) {
-            MpImmediate::I32(n as _)
-        } else {
-            todo!()
-        }
+        immediate_in_range!(n, u16, i16, u32, i32)
     }
 }
 

--- a/crates/mipsy_parser/src/number.rs
+++ b/crates/mipsy_parser/src/number.rs
@@ -81,6 +81,7 @@ impl TryFrom<i64> for MpImmediate {
 
 pub fn parse_number(i: Span<'_>) -> IResult<Span<'_>, MpNumber> {
     alt((
+        // map(map(parse_labelref, MpImmediate::LabelReference), MpNumber::Immediate),
         map(parse_constant_value, MpNumber::Constant),
         map(parse_immediate, MpNumber::Immediate),
         map(parse_f32, MpNumber::Float32),
@@ -219,10 +220,9 @@ pub fn parse_char(i: Span<'_>) -> IResult<Span<'_>, char> {
 }
 
 fn get_sign(neg: Option<char>) -> &'static str {
-    if let Some('-') = neg {
-        "-"
-    } else {
-        ""
+    match neg {
+        Some('-') => "-",
+        _ => "",
     }
 }
 


### PR DESCRIPTION
### changes 
do all your constant value operations inplace in immediate arguments

```
# confusing behaviour now fixed
li $0, 1+1 # works
li $0, 1*1 # didnt work :(

# fix some constant (both normal and immediate constants) error handling
a = 100000000*100000*1000000 # previously this would silently overflow and panic if used
    ^^^^^^^^^^^^^^^^^^^^^^^^ constant value must be between -9223372036854775808 and 9223372036854775807

# just evaluates the immediate arguments like they would work for a constant
# so like aswell as this
a = (1/2) + 2 << 2 + constant - label % 50 / 25 & 3 | -5 ^ -(30 + 2 >> 3)
li $0, a

# now this 
li $0, (1/2) + 2 << 2 + constant - label % 50 / 25 & 3 | -5 ^ -(30 + 2 >> 3)
```