### PR TITLE
smart interactive tab completion

### DIFF
--- a/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
@@ -39,7 +39,7 @@ pub(crate) fn command() -> Command {
                 "manage breakpoints ({} to list subcommands)",
                 "help breakpoint".bold()
         ))
-        .with_required_arg(Argument::subcommands())
+        .with_required_arg(Argument::Subcommand)
         .with_subcommand(
             Command::new()
             .with_name("list")
@@ -168,7 +168,7 @@ pub(crate) fn command() -> Command {
                     match cmd
                         .subcommands
                         .iter()
-                        .find(|c| c.names.contains(&args[0].to_owned().into()))
+                        .find(|c| c.names.contains(&args[0].to_owned().try_into().unwrap()))
                         {
                             Some(cmd) => (cmd._internal_exec)(cmd, helper, &args[1..]),
                             None => breakpoint_insert(&mut helper.state, &args_text(args), InsertOp::Insert),

--- a/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
@@ -204,7 +204,7 @@ fn get_long_help() -> String {
         "temporary".purple(),
         "ignore".purple(),
         "commands".purple(),
-    )
+        )
 }
 
 fn breakpoint_insert(
@@ -214,15 +214,15 @@ fn breakpoint_insert(
 ) -> Result<String, CommandError> {
     if args.is_empty() {
         return Err(generate_err(
-            CommandError::MissingArguments {
-                args: vec!["addr".to_string()],
-                instead: vec![],
-            },
-            match op {
-                InsertOp::Insert => "insert",
-                InsertOp::Delete => "delete",
-                InsertOp::Temporary => "temporary",
-            },
+                CommandError::MissingArguments {
+                    args: vec!["addr".to_string()],
+                    instead: vec![],
+                },
+                match op {
+                    InsertOp::Insert => "insert",
+                    InsertOp::Delete => "delete",
+                    InsertOp::Temporary => "temporary",
+                },
         ));
     }
 
@@ -242,13 +242,13 @@ fn breakpoint_insert(
             "removed"
         } else {
             prompt::error_nl(format!(
-                "breakpoint at {} doesn't exist",
-                match arg_type {
-                    MipsyArgType::LineNumber => args[0].as_str().into(),
-                    MipsyArgType::Immediate => args[0].white(),
-                    MipsyArgType::Label => args[0].yellow().bold(),
-                    MipsyArgType::Id => args[0].blue(),
-                }
+                    "breakpoint at {} doesn't exist",
+                    match arg_type {
+                        MipsyArgType::LineNumber => args[0].as_str().into(),
+                        MipsyArgType::Immediate => args[0].white(),
+                        MipsyArgType::Label => args[0].yellow().bold(),
+                        MipsyArgType::Id => args[0].blue(),
+                    }
             ));
             return Ok("".into());
         }
@@ -263,13 +263,13 @@ fn breakpoint_insert(
         "inserted"
     } else {
         prompt::error_nl(format!(
-            "breakpoint at {} already exists",
-            match arg_type {
-                MipsyArgType::LineNumber => args[0].as_str().into(),
-                MipsyArgType::Immediate => args[0].white(),
-                MipsyArgType::Label => args[0].yellow().bold(),
-                MipsyArgType::Id => args[0].blue(),
-            }
+                "breakpoint at {} already exists",
+                match arg_type {
+                    MipsyArgType::LineNumber => args[0].as_str().into(),
+                    MipsyArgType::Immediate => args[0].white(),
+                    MipsyArgType::Label => args[0].yellow().bold(),
+                    MipsyArgType::Id => args[0].blue(),
+        }
         ));
         return Ok("".into());
     };
@@ -289,18 +289,18 @@ fn breakpoint_insert(
 
     if let Some(label) = label {
         prompt::success_nl(format!(
-            "breakpoint {} {} at {} (0x{:08x})",
-            format!("!{}", id).blue(),
-            action,
-            label.yellow().bold(),
-            addr
+                "breakpoint {} {} at {} (0x{:08x})",
+                format!("!{}", id).blue(),
+                action,
+                label.yellow().bold(),
+                addr
         ));
     } else {
         prompt::success_nl(format!(
-            "breakpoint {} {} at 0x{:08x}",
-            format!("!{}", id).blue(),
-            action,
-            addr
+                "breakpoint {} {} at 0x{:08x}",
+                format!("!{}", id).blue(),
+                action,
+                addr
         ));
     }
 
@@ -330,14 +330,14 @@ fn breakpoint_list(state: &State) -> Result<String, CommandError> {
                 ),
                 addr,
                 binary
-                    .labels
-                    .iter()
-                    .find(|(_, &val)| val == addr)
-                    .map(|(name, _)| name),
+                .labels
+                .iter()
+                .find(|(_, &val)| val == addr)
+                .map(|(name, _)| name),
                 bp,
             )
         })
-        .collect::<Vec<_>>();
+    .collect::<Vec<_>>();
 
     breakpoints.sort_by_key(|(_, addr, _, _)| *addr);
 
@@ -397,15 +397,15 @@ fn breakpoint_toggle(
 ) -> Result<String, CommandError> {
     if args.is_empty() {
         return Err(generate_err(
-            CommandError::MissingArguments {
-                args: vec!["addr".to_string()],
-                instead: vec![],
-            },
-            match op {
-                EnableOp::Enable => "enable",
-                EnableOp::Disable => "disable",
-                EnableOp::Toggle => "toggle",
-            },
+                CommandError::MissingArguments {
+                    args: vec!["addr".to_string()],
+                    instead: vec![],
+                },
+                match op {
+                    EnableOp::Enable => "enable",
+                    EnableOp::Disable => "disable",
+                    EnableOp::Toggle => "toggle",
+                },
         ));
     }
 
@@ -428,13 +428,13 @@ fn breakpoint_toggle(
         }
     } else {
         prompt::error_nl(format!(
-            "breakpoint at {} doesn't exist",
-            match arg_type {
-                MipsyArgType::LineNumber => args[0].as_str().into(),
-                MipsyArgType::Immediate => args[0].white(),
-                MipsyArgType::Label => args[0].yellow().bold(),
-                MipsyArgType::Id => args[0].blue(),
-            }
+                "breakpoint at {} doesn't exist",
+                match arg_type {
+                    MipsyArgType::LineNumber => args[0].as_str().into(),
+                    MipsyArgType::Immediate => args[0].white(),
+                    MipsyArgType::Label => args[0].yellow().bold(),
+                    MipsyArgType::Id => args[0].blue(),
+                }
         ));
         return Ok("".into());
     }
@@ -460,18 +460,18 @@ fn breakpoint_toggle(
 
     if let Some(label) = label {
         prompt::success_nl(format!(
-            "breakpoint {} {} at {} (0x{:08x})",
-            format!("!{}", id).blue(),
-            action,
-            label.yellow().bold(),
-            addr
+                "breakpoint {} {} at {} (0x{:08x})",
+                format!("!{}", id).blue(),
+                action,
+                label.yellow().bold(),
+                addr
         ));
     } else {
         prompt::success_nl(format!(
-            "breakpoint {} {} at 0x{:08x}",
-            format!("!{}", id).blue(),
-            action,
-            addr
+                "breakpoint {} {} at 0x{:08x}",
+                format!("!{}", id).blue(),
+                action,
+                addr
         ));
     }
 
@@ -481,11 +481,11 @@ fn breakpoint_toggle(
 fn breakpoint_ignore(state: &mut State, args: &[String]) -> Result<String, CommandError> {
     if args.is_empty() {
         return Err(generate_err(
-            CommandError::MissingArguments {
-                args: vec!["addr".to_string()],
-                instead: vec![],
-            },
-            "ignore",
+                CommandError::MissingArguments {
+                    args: vec!["addr".to_string()],
+                    instead: vec![],
+                },
+                "ignore",
         ));
     }
 
@@ -499,11 +499,11 @@ fn breakpoint_ignore(state: &mut State, args: &[String]) -> Result<String, Comma
     let args = &args[1..];
     if args.is_empty() {
         return Err(generate_err(
-            CommandError::MissingArguments {
-                args: vec!["ignore count".to_string()],
-                instead: args.to_vec(),
-            },
-            "ignore",
+                CommandError::MissingArguments {
+                    args: vec!["ignore count".to_string()],
+                    instead: args.to_vec(),
+                },
+                "ignore",
         ));
     }
 
@@ -522,19 +522,19 @@ fn breakpoint_ignore(state: &mut State, args: &[String]) -> Result<String, Comma
     if let Some(br) = binary.breakpoints.get_mut(&addr) {
         br.ignore_count = ignore_count;
         prompt::success_nl(format!(
-            "skipping breakpoint {} {} times",
-            format!("!{}", br.id).blue(),
-            ignore_count.to_string().yellow()
+                "skipping breakpoint {} {} times",
+                format!("!{}", br.id).blue(),
+                ignore_count.to_string().yellow()
         ));
     } else {
         prompt::error_nl(format!(
-            "breakpoint at {} doesn't exist",
-            match arg_type {
-                MipsyArgType::LineNumber => args[0].as_str().into(),
-                MipsyArgType::Immediate => args[0].white(),
-                MipsyArgType::Label => args[0].yellow().bold(),
-                MipsyArgType::Id => args[0].blue(),
-            }
+                "breakpoint at {} doesn't exist",
+                match arg_type {
+                    MipsyArgType::LineNumber => args[0].as_str().into(),
+                    MipsyArgType::Immediate => args[0].white(),
+                    MipsyArgType::Label => args[0].yellow().bold(),
+                    MipsyArgType::Id => args[0].blue(),
+                }
         ));
     }
 
@@ -582,7 +582,7 @@ fn parse_breakpoint_arg(state: &State, arg: &String) -> Result<(u32, MipsyArgTyp
             .ok_or(CommandError::InvalidBpId {
                 arg: arg.to_string(),
             })?
-            .0;
+        .0;
 
         return Ok((*addr, MipsyArgType::Id));
     }
@@ -637,10 +637,10 @@ fn parse_breakpoint_arg(state: &State, arg: &String) -> Result<(u32, MipsyArgTyp
             MpImmediate::U32(imm) => (*imm, MipsyArgType::Immediate),
             MpImmediate::LabelReference(label) => (
                 binary
-                    .get_label(label)
-                    .map_err(|_| CommandError::UnknownLabel {
-                        label: label.to_string(),
-                    })?,
+                .get_label(label)
+                .map_err(|_| CommandError::UnknownLabel {
+                    label: label.to_string(),
+                })?,
                 MipsyArgType::Label,
             ),
         })
@@ -678,7 +678,7 @@ fn breakpoint_insert_help() -> String {
         "breakpoint".yellow().bold(),
         "{insert, delete, temporary}".purple(),
         "<temporary>".purple(),
-    )
+        )
 }
 
 fn breakpoint_toggle_help() -> String {

--- a/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
@@ -39,7 +39,7 @@ pub(crate) fn command() -> Command {
                 "manage breakpoints ({} to list subcommands)",
                 "help breakpoint".bold()
         ))
-        .with_optional_arg(Argument::subcommands())
+        .with_required_arg(Argument::subcommands())
         .with_subcommand(
             Command::new()
             .with_name("list")

--- a/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
@@ -44,7 +44,7 @@ pub(crate) fn command() -> Command {
             Command::new()
                 .with_name("list")
                 .with_name("l")
-                .with_exec(|_, state, label, _| breakpoint_list(state, label)),
+                .with_exec(|_, state, _, label, _| breakpoint_list(state, label)),
         )
         .with_subcommand(
             Command::new()
@@ -53,8 +53,8 @@ pub(crate) fn command() -> Command {
                 .with_name("in")
                 .with_name("ins")
                 .with_name("add")
-                .with_exec(|_, state, label, args| {
-                    breakpoint_insert(state, label, args, InsertOp::Insert)
+                .with_exec(|_, state, _, label, args| {
+                    breakpoint_insert(state, label, &args_text(args), InsertOp::Insert)
                 }),
         )
         .with_subcommand(
@@ -64,8 +64,8 @@ pub(crate) fn command() -> Command {
                 .with_name("delete")
                 .with_name("r")
                 .with_name("rm")
-                .with_exec(|_, state, label, args| {
-                    breakpoint_insert(state, label, args, InsertOp::Delete)
+                .with_exec(|_, state, _, label, args| {
+                    breakpoint_insert(state, label, &args_text(args), InsertOp::Delete)
                 }),
         )
         .with_subcommand(
@@ -73,29 +73,31 @@ pub(crate) fn command() -> Command {
                 .with_name("temporary")
                 .with_name("tmp")
                 .with_name("temp")
-                .with_exec(|_, state, label, args| {
-                    breakpoint_insert(state, label, args, InsertOp::Temporary)
+                .with_exec(|_, state, _, label, args| {
+                    breakpoint_insert(state, label, &args_text(args), InsertOp::Temporary)
                 }),
         )
         .with_subcommand(Command::new().with_name("enable").with_name("e").with_exec(
-            |_, state, label, args| breakpoint_toggle(state, label, args, EnableOp::Enable),
+            |_, state, _, label, args| {
+                breakpoint_toggle(state, label, &args_text(args), EnableOp::Enable)
+            },
         ))
         .with_subcommand(
             Command::new()
                 .with_name("disable")
                 .with_name("d")
-                .with_exec(|_, state, label, args| {
-                    breakpoint_toggle(state, label, args, EnableOp::Disable)
+                .with_exec(|_, state, _, label, args| {
+                    breakpoint_toggle(state, label, &args_text(args), EnableOp::Disable)
                 }),
         )
         .with_subcommand(Command::new().with_name("toggle").with_name("t").with_exec(
-            |_, state, label, args| breakpoint_toggle(state, label, args, EnableOp::Toggle),
+            |_, state, _, label, args| {
+                breakpoint_toggle(state, label, &args_text(args), EnableOp::Toggle)
+            },
         ))
-        .with_subcommand(
-            Command::new()
-                .with_name("ignore")
-                .with_exec(|_, state, label, args| breakpoint_ignore(state, label, args)),
-        )
+        .with_subcommand(Command::new().with_name("ignore").with_exec(
+            |_, state, _, label, args| breakpoint_ignore(state, label, &args_text(args)),
+        ))
         .with_subcommand(
             Command::new()
                 .with_name("commands")
@@ -104,21 +106,23 @@ pub(crate) fn command() -> Command {
                 .with_name("cmd")
                 .with_name("cmds")
                 .with_name("command")
-                .with_exec(|_, state, label, args| breakpoint_commands(state, label, args)),
+                .with_exec(|_, state, _, label, args| {
+                    breakpoint_commands(state, label, &args_text(args))
+                }),
         )
-        .with_exec(|cmd, state, label, args| {
+        .with_exec(|cmd, state, helper, label, args| {
             if label == "__help__" || args.is_empty() {
                 return Ok(get_long_help());
             }
 
-            match if let ArgumentKind::SubCommand(arg) = &args[0] {
-                cmd.subcommands.iter().find(|c| c.names.contains(&arg))
-            } else {
-                None
-            } {
+            match cmd
+                .subcommands
+                .iter()
+                .find(|c| c.names.contains(&args[0].to_owned().into()))
+            {
                 None if label == "__help__" => Ok(get_long_help()),
-                Some(cmd) => (cmd._internal_exec)(cmd, state, label, &args[1..]),
-                None => breakpoint_insert(state, label, args, InsertOp::Insert),
+                Some(cmd) => (cmd._internal_exec)(cmd, state, helper, label, &args[1..]),
+                None => breakpoint_insert(state, label, &args_text(args), InsertOp::Insert),
             }
         })
 }
@@ -157,7 +161,7 @@ fn get_long_help() -> String {
 fn breakpoint_insert(
     state: &mut State,
     label: &str,
-    args: &[ArgumentKind],
+    args: &[String],
     op: InsertOp,
 ) -> Result<String, CommandError> {
     if label == "__help__" {
@@ -208,8 +212,7 @@ fn breakpoint_insert(
         ));
     }
 
-    let args = args_text(args);
-    let (addr, arg_type) = parse_breakpoint_arg(state, args[0])?;
+    let (addr, arg_type) = parse_breakpoint_arg(state, &args[0])?;
 
     if addr % 4 != 0 {
         prompt::error_nl(format!("address 0x{:08x} should be word-aligned", addr));
@@ -259,7 +262,7 @@ fn breakpoint_insert(
 
     let label = match arg_type {
         MipsyArgType::Immediate => None,
-        MipsyArgType::Label => Some(args[0]),
+        MipsyArgType::Label => Some(&args[0]),
         MipsyArgType::Id | MipsyArgType::LineNumber => {
             let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
             binary
@@ -391,7 +394,7 @@ fn breakpoint_list(state: &State, label: &str) -> Result<String, CommandError> {
 fn breakpoint_toggle(
     state: &mut State,
     label: &str,
-    args: &[ArgumentKind],
+    args: &[String],
     op: EnableOp,
 ) -> Result<String, CommandError> {
     if label == "__help__" {
@@ -432,8 +435,7 @@ fn breakpoint_toggle(
         ));
     }
 
-    let args = args_text(args);
-    let (addr, arg_type) = parse_breakpoint_arg(state, args[0])?;
+    let (addr, arg_type) = parse_breakpoint_arg(state, &args[0])?;
 
     if addr % 4 != 0 {
         prompt::error_nl(format!("address 0x{:08x} should be word-aligned", addr));
@@ -471,7 +473,7 @@ fn breakpoint_toggle(
 
     let label = match arg_type {
         MipsyArgType::Immediate => None,
-        MipsyArgType::Label => Some(args[0]),
+        MipsyArgType::Label => Some(&args[0]),
         MipsyArgType::Id | MipsyArgType::LineNumber => {
             let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
             binary
@@ -505,7 +507,7 @@ fn breakpoint_toggle(
 fn breakpoint_ignore(
     state: &mut State,
     label: &str,
-    args: &[ArgumentKind],
+    args: &[String],
 ) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(
@@ -539,8 +541,7 @@ fn breakpoint_ignore(
         ));
     }
 
-    let args = args_text(args);
-    let (addr, arg_type) = parse_breakpoint_arg(state, args[0])?;
+    let (addr, arg_type) = parse_breakpoint_arg(state, &args[0])?;
 
     if addr % 4 != 0 {
         prompt::error_nl(format!("address 0x{:08x} should be word-aligned", addr));
@@ -552,7 +553,7 @@ fn breakpoint_ignore(
         return Err(generate_err(
             CommandError::MissingArguments {
                 args: vec!["ignore count".to_string()],
-                instead: args.iter().map(|&a| a.to_owned()).collect(),
+                instead: args.to_vec(),
             },
             "ignore",
         ));
@@ -595,7 +596,7 @@ fn breakpoint_ignore(
 fn breakpoint_commands(
     state: &mut State,
     label: &str,
-    args: &[ArgumentKind],
+    args: &[String],
 ) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(format!(
@@ -616,14 +617,7 @@ fn breakpoint_commands(
 
     let binary = state.binary.as_mut().ok_or(CommandError::MustLoadFile)?;
     state.confirm_exit = true;
-    handle_commands(
-        args_text(args)
-            .iter()
-            .map(|&a| a.to_owned())
-            .collect::<Vec<_>>()
-            .as_slice(),
-        &mut binary.breakpoints,
-    )
+    handle_commands(args, &mut binary.breakpoints)
 }
 
 fn generate_err(error: CommandError, command_name: impl Into<String>) -> CommandError {

--- a/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
@@ -56,7 +56,7 @@ pub(crate) fn command() -> Command {
                     "break".bold(),
                 ),
             )
-            .with_exec(|_, state, _, _| breakpoint_list(state)),
+            .with_exec(|_, helper, _| breakpoint_list(&helper.state)),
         )
         .with_subcommand(
             Command::new()
@@ -66,8 +66,8 @@ pub(crate) fn command() -> Command {
             .with_name("ins")
             .with_name("add")
             .with_help(breakpoint_insert_help())
-            .with_exec(|_, state, _, args| {
-                breakpoint_insert(state, &args_text(args), InsertOp::Insert)
+            .with_exec(|_, helper, args| {
+                breakpoint_insert(&mut helper.state, &args_text(args), InsertOp::Insert)
             }),
         )
         .with_subcommand(
@@ -78,8 +78,8 @@ pub(crate) fn command() -> Command {
             .with_name("r")
             .with_name("rm")
             .with_help(breakpoint_insert_help())
-            .with_exec(|_, state, _, args| {
-                breakpoint_insert(state, &args_text(args), InsertOp::Delete)
+            .with_exec(|_, helper, args| {
+                breakpoint_insert(&mut helper.state, &args_text(args), InsertOp::Delete)
             }),
         )
         .with_subcommand(
@@ -88,28 +88,28 @@ pub(crate) fn command() -> Command {
             .with_name("tmp")
             .with_name("temp")
             .with_help(breakpoint_insert_help())
-            .with_exec(|_, state, _, args| {
-                breakpoint_insert(state, &args_text(args), InsertOp::Temporary)
+            .with_exec(|_, helper, args| {
+                breakpoint_insert(&mut helper.state, &args_text(args), InsertOp::Temporary)
             }),
         )
         .with_subcommand(Command::new().with_name("enable").with_name("e").with_exec(
-                |_, state, _, args| {
-                    breakpoint_toggle(state, &args_text(args), EnableOp::Enable)
+                |_, helper, args| {
+                    breakpoint_toggle(&mut helper.state, &args_text(args), EnableOp::Enable)
                 },
         ))
         .with_subcommand(
             Command::new()
             .with_name("disable")
             .with_name("d")
-            .with_exec(|_, state, _, args| {
-                breakpoint_toggle(state, &args_text(args), EnableOp::Disable)
+            .with_exec(|_, helper, args| {
+                breakpoint_toggle(&mut helper.state, &args_text(args), EnableOp::Disable)
             }),
         )
         .with_subcommand(Command::new().with_name("toggle").with_name("t").
             with_help(breakpoint_toggle_help())
             .with_exec(
-                |_, state, _, args| {
-                    breakpoint_toggle(state, &args_text(args), EnableOp::Toggle)
+                |_, helper, args| {
+                    breakpoint_toggle(&mut helper.state, &args_text(args), EnableOp::Toggle)
                 },
             ))
         .with_subcommand(Command::new().with_name("ignore")
@@ -133,7 +133,7 @@ pub(crate) fn command() -> Command {
                 )
             )
             .with_exec(
-                |_, state, _, args| breakpoint_ignore(state, &args_text(args)),
+                |_, helper, args| breakpoint_ignore(&mut helper.state, &args_text(args)),
             ))
                 .with_subcommand(
                     Command::new()
@@ -159,19 +159,19 @@ pub(crate) fn command() -> Command {
                             "commands list".bold().yellow(),
                         )
                     )
-                    .with_exec(|_, state, _, args| {
-                        breakpoint_commands(state, &args_text(args))
+                    .with_exec(|_, helper, args| {
+                        breakpoint_commands(&mut helper.state, &args_text(args))
                     }),
             )
                 .with_help(get_long_help())
-                .with_exec(|cmd, state, helper, args| {
+                .with_exec(|cmd, helper, args| {
                     match cmd
                         .subcommands
                         .iter()
                         .find(|c| c.names.contains(&args[0].to_owned().into()))
                         {
-                            Some(cmd) => (cmd._internal_exec)(cmd, state, helper, &args[1..]),
-                            None => breakpoint_insert(state, &args_text(args), InsertOp::Insert),
+                            Some(cmd) => (cmd._internal_exec)(cmd, helper, &args[1..]),
+                            None => breakpoint_insert(&mut helper.state, &args_text(args), InsertOp::Insert),
                         }
                 })
 }
@@ -204,7 +204,7 @@ fn get_long_help() -> String {
         "temporary".purple(),
         "ignore".purple(),
         "commands".purple(),
-        )
+    )
 }
 
 fn breakpoint_insert(
@@ -214,15 +214,15 @@ fn breakpoint_insert(
 ) -> Result<String, CommandError> {
     if args.is_empty() {
         return Err(generate_err(
-                CommandError::MissingArguments {
-                    args: vec!["addr".to_string()],
-                    instead: vec![],
-                },
-                match op {
-                    InsertOp::Insert => "insert",
-                    InsertOp::Delete => "delete",
-                    InsertOp::Temporary => "temporary",
-                },
+            CommandError::MissingArguments {
+                args: vec!["addr".to_string()],
+                instead: vec![],
+            },
+            match op {
+                InsertOp::Insert => "insert",
+                InsertOp::Delete => "delete",
+                InsertOp::Temporary => "temporary",
+            },
         ));
     }
 
@@ -242,13 +242,13 @@ fn breakpoint_insert(
             "removed"
         } else {
             prompt::error_nl(format!(
-                    "breakpoint at {} doesn't exist",
-                    match arg_type {
-                        MipsyArgType::LineNumber => args[0].as_str().into(),
-                        MipsyArgType::Immediate => args[0].white(),
-                        MipsyArgType::Label => args[0].yellow().bold(),
-                        MipsyArgType::Id => args[0].blue(),
-                    }
+                "breakpoint at {} doesn't exist",
+                match arg_type {
+                    MipsyArgType::LineNumber => args[0].as_str().into(),
+                    MipsyArgType::Immediate => args[0].white(),
+                    MipsyArgType::Label => args[0].yellow().bold(),
+                    MipsyArgType::Id => args[0].blue(),
+                }
             ));
             return Ok("".into());
         }
@@ -263,13 +263,13 @@ fn breakpoint_insert(
         "inserted"
     } else {
         prompt::error_nl(format!(
-                "breakpoint at {} already exists",
-                match arg_type {
-                    MipsyArgType::LineNumber => args[0].as_str().into(),
-                    MipsyArgType::Immediate => args[0].white(),
-                    MipsyArgType::Label => args[0].yellow().bold(),
-                    MipsyArgType::Id => args[0].blue(),
-        }
+            "breakpoint at {} already exists",
+            match arg_type {
+                MipsyArgType::LineNumber => args[0].as_str().into(),
+                MipsyArgType::Immediate => args[0].white(),
+                MipsyArgType::Label => args[0].yellow().bold(),
+                MipsyArgType::Id => args[0].blue(),
+            }
         ));
         return Ok("".into());
     };
@@ -289,18 +289,18 @@ fn breakpoint_insert(
 
     if let Some(label) = label {
         prompt::success_nl(format!(
-                "breakpoint {} {} at {} (0x{:08x})",
-                format!("!{}", id).blue(),
-                action,
-                label.yellow().bold(),
-                addr
+            "breakpoint {} {} at {} (0x{:08x})",
+            format!("!{}", id).blue(),
+            action,
+            label.yellow().bold(),
+            addr
         ));
     } else {
         prompt::success_nl(format!(
-                "breakpoint {} {} at 0x{:08x}",
-                format!("!{}", id).blue(),
-                action,
-                addr
+            "breakpoint {} {} at 0x{:08x}",
+            format!("!{}", id).blue(),
+            action,
+            addr
         ));
     }
 
@@ -330,14 +330,14 @@ fn breakpoint_list(state: &State) -> Result<String, CommandError> {
                 ),
                 addr,
                 binary
-                .labels
-                .iter()
-                .find(|(_, &val)| val == addr)
-                .map(|(name, _)| name),
+                    .labels
+                    .iter()
+                    .find(|(_, &val)| val == addr)
+                    .map(|(name, _)| name),
                 bp,
             )
         })
-    .collect::<Vec<_>>();
+        .collect::<Vec<_>>();
 
     breakpoints.sort_by_key(|(_, addr, _, _)| *addr);
 
@@ -397,15 +397,15 @@ fn breakpoint_toggle(
 ) -> Result<String, CommandError> {
     if args.is_empty() {
         return Err(generate_err(
-                CommandError::MissingArguments {
-                    args: vec!["addr".to_string()],
-                    instead: vec![],
-                },
-                match op {
-                    EnableOp::Enable => "enable",
-                    EnableOp::Disable => "disable",
-                    EnableOp::Toggle => "toggle",
-                },
+            CommandError::MissingArguments {
+                args: vec!["addr".to_string()],
+                instead: vec![],
+            },
+            match op {
+                EnableOp::Enable => "enable",
+                EnableOp::Disable => "disable",
+                EnableOp::Toggle => "toggle",
+            },
         ));
     }
 
@@ -428,13 +428,13 @@ fn breakpoint_toggle(
         }
     } else {
         prompt::error_nl(format!(
-                "breakpoint at {} doesn't exist",
-                match arg_type {
-                    MipsyArgType::LineNumber => args[0].as_str().into(),
-                    MipsyArgType::Immediate => args[0].white(),
-                    MipsyArgType::Label => args[0].yellow().bold(),
-                    MipsyArgType::Id => args[0].blue(),
-                }
+            "breakpoint at {} doesn't exist",
+            match arg_type {
+                MipsyArgType::LineNumber => args[0].as_str().into(),
+                MipsyArgType::Immediate => args[0].white(),
+                MipsyArgType::Label => args[0].yellow().bold(),
+                MipsyArgType::Id => args[0].blue(),
+            }
         ));
         return Ok("".into());
     }
@@ -460,18 +460,18 @@ fn breakpoint_toggle(
 
     if let Some(label) = label {
         prompt::success_nl(format!(
-                "breakpoint {} {} at {} (0x{:08x})",
-                format!("!{}", id).blue(),
-                action,
-                label.yellow().bold(),
-                addr
+            "breakpoint {} {} at {} (0x{:08x})",
+            format!("!{}", id).blue(),
+            action,
+            label.yellow().bold(),
+            addr
         ));
     } else {
         prompt::success_nl(format!(
-                "breakpoint {} {} at 0x{:08x}",
-                format!("!{}", id).blue(),
-                action,
-                addr
+            "breakpoint {} {} at 0x{:08x}",
+            format!("!{}", id).blue(),
+            action,
+            addr
         ));
     }
 
@@ -481,11 +481,11 @@ fn breakpoint_toggle(
 fn breakpoint_ignore(state: &mut State, args: &[String]) -> Result<String, CommandError> {
     if args.is_empty() {
         return Err(generate_err(
-                CommandError::MissingArguments {
-                    args: vec!["addr".to_string()],
-                    instead: vec![],
-                },
-                "ignore",
+            CommandError::MissingArguments {
+                args: vec!["addr".to_string()],
+                instead: vec![],
+            },
+            "ignore",
         ));
     }
 
@@ -499,11 +499,11 @@ fn breakpoint_ignore(state: &mut State, args: &[String]) -> Result<String, Comma
     let args = &args[1..];
     if args.is_empty() {
         return Err(generate_err(
-                CommandError::MissingArguments {
-                    args: vec!["ignore count".to_string()],
-                    instead: args.to_vec(),
-                },
-                "ignore",
+            CommandError::MissingArguments {
+                args: vec!["ignore count".to_string()],
+                instead: args.to_vec(),
+            },
+            "ignore",
         ));
     }
 
@@ -522,19 +522,19 @@ fn breakpoint_ignore(state: &mut State, args: &[String]) -> Result<String, Comma
     if let Some(br) = binary.breakpoints.get_mut(&addr) {
         br.ignore_count = ignore_count;
         prompt::success_nl(format!(
-                "skipping breakpoint {} {} times",
-                format!("!{}", br.id).blue(),
-                ignore_count.to_string().yellow()
+            "skipping breakpoint {} {} times",
+            format!("!{}", br.id).blue(),
+            ignore_count.to_string().yellow()
         ));
     } else {
         prompt::error_nl(format!(
-                "breakpoint at {} doesn't exist",
-                match arg_type {
-                    MipsyArgType::LineNumber => args[0].as_str().into(),
-                    MipsyArgType::Immediate => args[0].white(),
-                    MipsyArgType::Label => args[0].yellow().bold(),
-                    MipsyArgType::Id => args[0].blue(),
-                }
+            "breakpoint at {} doesn't exist",
+            match arg_type {
+                MipsyArgType::LineNumber => args[0].as_str().into(),
+                MipsyArgType::Immediate => args[0].white(),
+                MipsyArgType::Label => args[0].yellow().bold(),
+                MipsyArgType::Id => args[0].blue(),
+            }
         ));
     }
 
@@ -543,7 +543,6 @@ fn breakpoint_ignore(state: &mut State, args: &[String]) -> Result<String, Comma
 
 fn breakpoint_commands(state: &mut State, args: &[String]) -> Result<String, CommandError> {
     let binary = state.binary.as_mut().ok_or(CommandError::MustLoadFile)?;
-    state.confirm_exit = true;
     handle_commands(args, &mut binary.breakpoints)
 }
 
@@ -582,7 +581,7 @@ fn parse_breakpoint_arg(state: &State, arg: &String) -> Result<(u32, MipsyArgTyp
             .ok_or(CommandError::InvalidBpId {
                 arg: arg.to_string(),
             })?
-        .0;
+            .0;
 
         return Ok((*addr, MipsyArgType::Id));
     }
@@ -637,10 +636,10 @@ fn parse_breakpoint_arg(state: &State, arg: &String) -> Result<(u32, MipsyArgTyp
             MpImmediate::U32(imm) => (*imm, MipsyArgType::Immediate),
             MpImmediate::LabelReference(label) => (
                 binary
-                .get_label(label)
-                .map_err(|_| CommandError::UnknownLabel {
-                    label: label.to_string(),
-                })?,
+                    .get_label(label)
+                    .map_err(|_| CommandError::UnknownLabel {
+                        label: label.to_string(),
+                    })?,
                 MipsyArgType::Label,
             ),
         })
@@ -678,7 +677,7 @@ fn breakpoint_insert_help() -> String {
         "breakpoint".yellow().bold(),
         "{insert, delete, temporary}".purple(),
         "<temporary>".purple(),
-        )
+    )
 }
 
 fn breakpoint_toggle_help() -> String {

--- a/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
@@ -2,6 +2,7 @@ use crate::interactive::{error::CommandError, prompt};
 use std::iter::successors;
 
 use super::{commands::handle_commands, *};
+use crate::interactive::commands::watchpoint::args_text;
 use colored::*;
 use mipsy_lib::{compile::breakpoints::Breakpoint, Binary};
 use mipsy_parser::*;
@@ -26,117 +27,102 @@ enum MipsyArgType {
     Id,
 }
 
-pub(crate) fn breakpoint_command() -> Command {
-    let subcommands = vec![
-        command(
-            "list",
-            vec!["l"],
-            vec![],
-            vec![],
-            vec![],
-            "",
-            |_, state, label, args| breakpoint_list(state, label, args),
-        ),
-        command(
-            "insert",
-            vec!["i", "in", "ins", "add"],
-            vec![],
-            vec![],
-            vec![],
-            "",
-            |_, state, label, args| breakpoint_insert(state, label, args, InsertOp::Insert),
-        ),
-        command(
-            "remove",
-            vec!["del", "delete", "r", "rm"],
-            vec![],
-            vec![],
-            vec![],
-            "",
-            |_, state, label, args| breakpoint_insert(state, label, args, InsertOp::Delete),
-        ),
-        command(
-            "temporary",
-            vec!["tmp", "temp"],
-            vec![],
-            vec![],
-            vec![],
-            "",
-            |_, state, label, args| breakpoint_insert(state, label, args, InsertOp::Temporary),
-        ),
-        command(
-            "enable",
-            vec!["e"],
-            vec![],
-            vec![],
-            vec![],
-            "",
-            |_, state, label, args| breakpoint_toggle(state, label, args, EnableOp::Enable),
-        ),
-        command(
-            "disable",
-            vec!["d"],
-            vec![],
-            vec![],
-            vec![],
-            "",
-            |_, state, label, args| breakpoint_toggle(state, label, args, EnableOp::Disable),
-        ),
-        command(
-            "toggle",
-            vec!["t"],
-            vec![],
-            vec![],
-            vec![],
-            "",
-            |_, state, label, args| breakpoint_toggle(state, label, args, EnableOp::Toggle),
-        ),
-        command(
-            "ignore",
-            vec![],
-            vec![],
-            vec![],
-            vec![],
-            "",
-            |_, state, label, args| breakpoint_ignore(state, label, args),
-        ),
-        command(
-            "commands",
-            vec!["com", "comms", "cmd", "cmds", "command"],
-            vec![],
-            vec![],
-            vec![],
-            "",
-            |_, state, label, args| breakpoint_commands(state, label, args),
-        ),
-    ];
-
-    command(
-        "breakpoint",
-        vec!["b", "bp", "br", "brk", "break"],
-        vec!["subcommand"],
-        vec![],
-        subcommands,
-        &format!(
+pub(crate) fn command() -> Command {
+    Command::new()
+        .with_name("breakpoint")
+        .with_name("b")
+        .with_name("bp")
+        .with_name("br")
+        .with_name("brk")
+        .with_name("break")
+        .with_desc(format!(
             "manage breakpoints ({} to list subcommands)",
             "help breakpoint".bold()
-        ),
-        |cmd, state, label, args| {
-            if label == "__help__" && args.is_empty() {
+        ))
+        .with_optional_arg(Argument::new("subcommand", |a| {
+            Ok(ArgumentKind::Any(a.to_owned()))
+        }))
+        .with_subcommand(
+            Command::new()
+                .with_name("list")
+                .with_name("l")
+                .with_exec(|_, state, label, _| breakpoint_list(state, label)),
+        )
+        .with_subcommand(
+            Command::new()
+                .with_name("insert")
+                .with_name("i")
+                .with_name("in")
+                .with_name("ins")
+                .with_name("add")
+                .with_exec(|_, state, label, args| {
+                    breakpoint_insert(state, label, args, InsertOp::Insert)
+                }),
+        )
+        .with_subcommand(
+            Command::new()
+                .with_name("remove")
+                .with_name("del")
+                .with_name("delete")
+                .with_name("r")
+                .with_name("rm")
+                .with_exec(|_, state, label, args| {
+                    breakpoint_insert(state, label, args, InsertOp::Delete)
+                }),
+        )
+        .with_subcommand(
+            Command::new()
+                .with_name("temporary")
+                .with_name("tmp")
+                .with_name("temp")
+                .with_exec(|_, state, label, args| {
+                    breakpoint_insert(state, label, args, InsertOp::Temporary)
+                }),
+        )
+        .with_subcommand(Command::new().with_name("enable").with_name("e").with_exec(
+            |_, state, label, args| breakpoint_toggle(state, label, args, EnableOp::Enable),
+        ))
+        .with_subcommand(
+            Command::new()
+                .with_name("disable")
+                .with_name("d")
+                .with_exec(|_, state, label, args| {
+                    breakpoint_toggle(state, label, args, EnableOp::Disable)
+                }),
+        )
+        .with_subcommand(Command::new().with_name("toggle").with_name("t").with_exec(
+            |_, state, label, args| breakpoint_toggle(state, label, args, EnableOp::Toggle),
+        ))
+        .with_subcommand(
+            Command::new()
+                .with_name("ignore")
+                .with_exec(|_, state, label, args| breakpoint_ignore(state, label, args)),
+        )
+        .with_subcommand(
+            Command::new()
+                .with_name("commands")
+                .with_name("com")
+                .with_name("comms")
+                .with_name("cmd")
+                .with_name("cmds")
+                .with_name("command")
+                .with_exec(|_, state, label, args| breakpoint_commands(state, label, args)),
+        )
+        .with_exec(|cmd, state, label, args| {
+            if label == "__help__" || args.is_empty() {
                 return Ok(get_long_help());
             }
 
-            let cmd = cmd
-                .subcommands
-                .iter()
-                .find(|c| c.name == args[0] || c.aliases.contains(&args[0]));
-            match cmd {
+            match if let ArgumentKind::SubCommand(arg) = &args[0] {
+                cmd.subcommands.iter().find(|c| c.names.contains(&arg))
+            } else {
+                None
+            } {
                 None if label == "__help__" => Ok(get_long_help()),
-                Some(cmd) => cmd.exec(state, label, &args[1..]),
+                Some(cmd) => (cmd._internal_exec)(cmd, state, label, &args[1..]),
                 None => breakpoint_insert(state, label, args, InsertOp::Insert),
             }
-        },
-    )
+        })
 }
 
 fn get_long_help() -> String {
@@ -173,7 +159,7 @@ fn get_long_help() -> String {
 fn breakpoint_insert(
     state: &mut State,
     label: &str,
-    args: &[String],
+    args: &[ArgumentKind],
     op: InsertOp,
 ) -> Result<String, CommandError> {
     if label == "__help__" {
@@ -214,7 +200,7 @@ fn breakpoint_insert(
         return Err(generate_err(
             CommandError::MissingArguments {
                 args: vec!["addr".to_string()],
-                instead: args.to_vec(),
+                instead: vec![],
             },
             match op {
                 InsertOp::Insert => "insert",
@@ -224,7 +210,8 @@ fn breakpoint_insert(
         ));
     }
 
-    let (addr, arg_type) = parse_breakpoint_arg(state, &args[0])?;
+    let args = args_text(args);
+    let (addr, arg_type) = parse_breakpoint_arg(state, args[0])?;
 
     if addr % 4 != 0 {
         prompt::error_nl(format!("address 0x{:08x} should be word-aligned", addr));
@@ -274,7 +261,7 @@ fn breakpoint_insert(
 
     let label = match arg_type {
         MipsyArgType::Immediate => None,
-        MipsyArgType::Label => Some(&args[0]),
+        MipsyArgType::Label => Some(args[0]),
         MipsyArgType::Id | MipsyArgType::LineNumber => {
             let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
             binary
@@ -305,7 +292,7 @@ fn breakpoint_insert(
     Ok("".into())
 }
 
-fn breakpoint_list(state: &State, label: &str, _args: &[String]) -> Result<String, CommandError> {
+fn breakpoint_list(state: &State, label: &str) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(
             format!(
@@ -406,7 +393,7 @@ fn breakpoint_list(state: &State, label: &str, _args: &[String]) -> Result<Strin
 fn breakpoint_toggle(
     state: &mut State,
     label: &str,
-    args: &[String],
+    args: &[ArgumentKind],
     op: EnableOp,
 ) -> Result<String, CommandError> {
     if label == "__help__" {
@@ -437,7 +424,7 @@ fn breakpoint_toggle(
         return Err(generate_err(
             CommandError::MissingArguments {
                 args: vec!["addr".to_string()],
-                instead: args.to_vec(),
+                instead: vec![],
             },
             match op {
                 EnableOp::Enable => "enable",
@@ -447,7 +434,8 @@ fn breakpoint_toggle(
         ));
     }
 
-    let (addr, arg_type) = parse_breakpoint_arg(state, &args[0])?;
+    let args = args_text(args);
+    let (addr, arg_type) = parse_breakpoint_arg(state, args[0])?;
 
     if addr % 4 != 0 {
         prompt::error_nl(format!("address 0x{:08x} should be word-aligned", addr));
@@ -485,7 +473,7 @@ fn breakpoint_toggle(
 
     let label = match arg_type {
         MipsyArgType::Immediate => None,
-        MipsyArgType::Label => Some(&args[0]),
+        MipsyArgType::Label => Some(args[0]),
         MipsyArgType::Id | MipsyArgType::LineNumber => {
             let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
             binary
@@ -519,7 +507,7 @@ fn breakpoint_toggle(
 fn breakpoint_ignore(
     state: &mut State,
     label: &str,
-    mut args: &[String],
+    args: &[ArgumentKind],
 ) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(
@@ -547,25 +535,26 @@ fn breakpoint_ignore(
         return Err(generate_err(
             CommandError::MissingArguments {
                 args: vec!["addr".to_string()],
-                instead: args.to_vec(),
+                instead: vec![],
             },
             "ignore",
         ));
     }
 
-    let (addr, arg_type) = parse_breakpoint_arg(state, &args[0])?;
+    let args = args_text(args);
+    let (addr, arg_type) = parse_breakpoint_arg(state, args[0])?;
 
     if addr % 4 != 0 {
         prompt::error_nl(format!("address 0x{:08x} should be word-aligned", addr));
         return Ok("".into());
     }
 
-    args = &args[1..];
+    let args = &args[1..];
     if args.is_empty() {
         return Err(generate_err(
             CommandError::MissingArguments {
                 args: vec!["ignore count".to_string()],
-                instead: args.to_vec(),
+                instead: args.iter().map(|&a| a.to_owned()).collect(),
             },
             "ignore",
         ));
@@ -608,7 +597,7 @@ fn breakpoint_ignore(
 fn breakpoint_commands(
     state: &mut State,
     label: &str,
-    args: &[String],
+    args: &[ArgumentKind],
 ) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(format!(
@@ -629,7 +618,14 @@ fn breakpoint_commands(
 
     let binary = state.binary.as_mut().ok_or(CommandError::MustLoadFile)?;
     state.confirm_exit = true;
-    handle_commands(args, &mut binary.breakpoints)
+    handle_commands(
+        args_text(args)
+            .iter()
+            .map(|&a| a.to_owned())
+            .collect::<Vec<_>>()
+            .as_slice(),
+        &mut binary.breakpoints,
+    )
 }
 
 fn generate_err(error: CommandError, command_name: impl Into<String>) -> CommandError {

--- a/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
@@ -36,110 +36,159 @@ pub(crate) fn command() -> Command {
         .with_name("brk")
         .with_name("break")
         .with_desc(format!(
-            "manage breakpoints ({} to list subcommands)",
-            "help breakpoint".bold()
+                "manage breakpoints ({} to list subcommands)",
+                "help breakpoint".bold()
         ))
         .with_optional_arg(Argument::subcommands())
         .with_subcommand(
             Command::new()
-                .with_name("list")
-                .with_name("l")
-                .with_exec(|_, state, _, label, _| breakpoint_list(state, label)),
+            .with_name("list")
+            .with_name("l")
+            .with_help(
+                format!(
+                    "Lists currently set breakpoints.\n\
+                    When running or stepping through your program, a breakpoint will cause execution to\n\
+                    pause temporarily, allowing you to debug the current state.\n\
+                    May error if provided a label that doesn't exist.\n\
+                    \n{}{} you can also use the `{}` mips instruction in your program's code!",
+                    "tip".yellow().bold(),
+                    ":".bold(),
+                    "break".bold(),
+                ),
+            )
+            .with_exec(|_, state, _, _| breakpoint_list(state)),
         )
         .with_subcommand(
             Command::new()
-                .with_name("insert")
-                .with_name("i")
-                .with_name("in")
-                .with_name("ins")
-                .with_name("add")
-                .with_exec(|_, state, _, label, args| {
-                    breakpoint_insert(state, label, &args_text(args), InsertOp::Insert)
-                }),
+            .with_name("insert")
+            .with_name("i")
+            .with_name("in")
+            .with_name("ins")
+            .with_name("add")
+            .with_help(breakpoint_insert_help())
+            .with_exec(|_, state, _, args| {
+                breakpoint_insert(state, &args_text(args), InsertOp::Insert)
+            }),
         )
         .with_subcommand(
             Command::new()
-                .with_name("remove")
-                .with_name("del")
-                .with_name("delete")
-                .with_name("r")
-                .with_name("rm")
-                .with_exec(|_, state, _, label, args| {
-                    breakpoint_insert(state, label, &args_text(args), InsertOp::Delete)
-                }),
+            .with_name("remove")
+            .with_name("del")
+            .with_name("delete")
+            .with_name("r")
+            .with_name("rm")
+            .with_help(breakpoint_insert_help())
+            .with_exec(|_, state, _, args| {
+                breakpoint_insert(state, &args_text(args), InsertOp::Delete)
+            }),
         )
         .with_subcommand(
             Command::new()
-                .with_name("temporary")
-                .with_name("tmp")
-                .with_name("temp")
-                .with_exec(|_, state, _, label, args| {
-                    breakpoint_insert(state, label, &args_text(args), InsertOp::Temporary)
-                }),
+            .with_name("temporary")
+            .with_name("tmp")
+            .with_name("temp")
+            .with_help(breakpoint_insert_help())
+            .with_exec(|_, state, _, args| {
+                breakpoint_insert(state, &args_text(args), InsertOp::Temporary)
+            }),
         )
         .with_subcommand(Command::new().with_name("enable").with_name("e").with_exec(
-            |_, state, _, label, args| {
-                breakpoint_toggle(state, label, &args_text(args), EnableOp::Enable)
-            },
+                |_, state, _, args| {
+                    breakpoint_toggle(state, &args_text(args), EnableOp::Enable)
+                },
         ))
         .with_subcommand(
             Command::new()
-                .with_name("disable")
-                .with_name("d")
-                .with_exec(|_, state, _, label, args| {
-                    breakpoint_toggle(state, label, &args_text(args), EnableOp::Disable)
-                }),
+            .with_name("disable")
+            .with_name("d")
+            .with_exec(|_, state, _, args| {
+                breakpoint_toggle(state, &args_text(args), EnableOp::Disable)
+            }),
         )
-        .with_subcommand(Command::new().with_name("toggle").with_name("t").with_exec(
-            |_, state, _, label, args| {
-                breakpoint_toggle(state, label, &args_text(args), EnableOp::Toggle)
-            },
-        ))
-        .with_subcommand(Command::new().with_name("ignore").with_exec(
-            |_, state, _, label, args| breakpoint_ignore(state, label, &args_text(args)),
-        ))
-        .with_subcommand(
-            Command::new()
-                .with_name("commands")
-                .with_name("com")
-                .with_name("comms")
-                .with_name("cmd")
-                .with_name("cmds")
-                .with_name("command")
-                .with_exec(|_, state, _, label, args| {
-                    breakpoint_commands(state, label, &args_text(args))
-                }),
-        )
-        .with_exec(|cmd, state, helper, label, args| {
-            if label == "__help__" || args.is_empty() {
-                return Ok(get_long_help());
-            }
-
-            match cmd
-                .subcommands
-                .iter()
-                .find(|c| c.names.contains(&args[0].to_owned().into()))
-            {
-                None if label == "__help__" => Ok(get_long_help()),
-                Some(cmd) => (cmd._internal_exec)(cmd, state, helper, label, &args[1..]),
-                None => breakpoint_insert(state, label, &args_text(args), InsertOp::Insert),
-            }
-        })
+        .with_subcommand(Command::new().with_name("toggle").with_name("t").
+            with_help(breakpoint_toggle_help())
+            .with_exec(
+                |_, state, _, args| {
+                    breakpoint_toggle(state, &args_text(args), EnableOp::Toggle)
+                },
+            ))
+        .with_subcommand(Command::new().with_name("ignore")
+            .with_help(
+                format!(
+                    "Usage: {6} {7} {1} {0}\n\
+                    {7}s a breakpoint at the specified {1} for the next {0} hits.\n\
+                    {1} may be: a decimal address (`4194304`), a hex address (`{2}400000`),\n\
+                    \x20                 a label (`{3}`), a line number (`:14`, `prog.s:7`), or an id (`{4}`).\n\
+                    Breakpoints that are ignored do not trigger when they are hit.\n\
+                    Breakpoints caused by the `{5}` instruction in code cannot ignored.
+                    ",
+                    "<ignore count>".purple(),
+                    "<address>".purple(),
+                    "0x".yellow(),
+                    "main".yellow().bold(),
+                    "!3".blue(),
+                    "break".bold(),
+                    "breakpoint".yellow().bold(),
+                    "ignore".purple(),
+                )
+            )
+            .with_exec(
+                |_, state, _, args| breakpoint_ignore(state, &args_text(args)),
+            ))
+                .with_subcommand(
+                    Command::new()
+                    .with_name("commands")
+                    .with_name("com")
+                    .with_name("comms")
+                    .with_name("cmd")
+                    .with_name("cmds")
+                    .with_name("command")
+                    .with_help(
+                        format!(
+                            "Takes in a list of commands seperated by newlines,\n\
+                            and attaches the commands to the specified {0}.\n\
+                            If no breakpoint is specified, the most recently created breakpoint is chosen.\n\
+                            Whenever that breakpoint is hit, the commands will automatically be executed\n\
+                            in the provided order.\n\
+                            The list of commands can be ended using the {1} command, EOF, or an empty line.\n\
+                            To view the commands attached to a particular breakpoint,\n\
+                            use {2} {0}
+                            ",
+                            "<breakpoint id>".purple(),
+                            "end".yellow().bold(),
+                            "commands list".bold().yellow(),
+                        )
+                    )
+                    .with_exec(|_, state, _, args| {
+                        breakpoint_commands(state, &args_text(args))
+                    }),
+            )
+                .with_help(get_long_help())
+                .with_exec(|cmd, state, helper, args| {
+                    match cmd
+                        .subcommands
+                        .iter()
+                        .find(|c| c.names.contains(&args[0].to_owned().into()))
+                        {
+                            Some(cmd) => (cmd._internal_exec)(cmd, state, helper, &args[1..]),
+                            None => breakpoint_insert(state, &args_text(args), InsertOp::Insert),
+                        }
+                })
 }
 
 fn get_long_help() -> String {
     format!(
         "A collection of commands for managing breakpoints. Available {10}s are:\n\n\
-         {0} {2}    : insert/delete a breakpoint\n\
-         {1} {3}\n\
-         {0} {11} : insert a temporary breakpoint that deletes itself after being hit\n\
-         {0} {13}  : attach commands to a breakpoint\n\
-         {0} {5}    : enable/disable an existing breakpoint\n\
-         {1} {6}\n\
-         {1} {7}\n\
-         {0} {12}    : ignore a breakpoint for a specified number of hits\n\
-         {0} {4}      : list currently set breakpoints\n\n\
-         {8} {9} will provide more information about the specified subcommand.
+        {0} {2}    : insert/delete a breakpoint\n\
+        {1} {3}\n\
+        {0} {11} : insert a temporary breakpoint that deletes itself after being hit\n\
+        {0} {13}  : attach commands to a breakpoint\n\
+        {0} {5}    : enable/disable an existing breakpoint\n\
+        {1} {6}\n\
+        {1} {7}\n\
+        {0} {12}    : ignore a breakpoint for a specified number of hits\n\
+        {0} {4}      : list currently set breakpoints\n\n\
+        {8} {9} will provide more information about the specified subcommand.
         ",
         "breakpoint".yellow().bold(),
         "          ".yellow().bold(),
@@ -160,44 +209,9 @@ fn get_long_help() -> String {
 
 fn breakpoint_insert(
     state: &mut State,
-    label: &str,
     args: &[String],
     op: InsertOp,
 ) -> Result<String, CommandError> {
-    if label == "__help__" {
-        return Ok(
-            format!(
-                "Usage: {10} {11} {2}\n\
-                 {0}s or {1}s a breakpoint at the specified {2}.\n\
-                 {2} may be: a decimal address (`4194304`), a hex address (`{3}400000`),\n\
-            \x20             a label (`{4}`), or a line number (`:14`, `prog.s:7`).\n\
-                 If you are removing a breakpoint, you can also use its id (`{5}`).\n\
-                 {6} must be `i`, `in`, `ins`, `insert`, or `add` to insert the breakpoint, or\n\
-            \x20             `del`, `delete`, `rm` or `remove` to remove the breakpoint.\n\
-                 If {12}, `tmp`, or `temp` is provided as the {6}, the breakpoint will\n\
-                 be created as a temporary breakpoint, which automatically deletes itself after being hit.\n\
-                 If {6} is none of these option, it defaults to inserting a breakpoint at {6}.\n\
-                 When running or stepping through your program, a breakpoint will cause execution to\n\
-                 pause temporarily, allowing you to debug the current state.\n\
-                 May error if provided a label that doesn't exist.\n\
-              \n{7}{8} you can also use the `{9}` MIPS instruction in your program's code!",
-                "<insert>".magenta(),
-                "<delete>".magenta(),
-                "<address>".magenta(),
-                "0x".yellow(),
-                "main".yellow().bold(),
-                "!3".blue(),
-                "<subcommand>".magenta(),
-                "tip".yellow().bold(),
-                ":".bold(),
-                "break".bold(),
-                "breakpoint".yellow().bold(),
-                "{insert, delete, temporary}".purple(),
-                "<temporary>".purple(),
-            )
-        );
-    }
-
     if args.is_empty() {
         return Err(generate_err(
             CommandError::MissingArguments {
@@ -293,22 +307,7 @@ fn breakpoint_insert(
     Ok("".into())
 }
 
-fn breakpoint_list(state: &State, label: &str) -> Result<String, CommandError> {
-    if label == "__help__" {
-        return Ok(
-            format!(
-                "Lists currently set breakpoints.\n\
-                 When running or stepping through your program, a breakpoint will cause execution to\n\
-                 pause temporarily, allowing you to debug the current state.\n\
-                 May error if provided a label that doesn't exist.\n\
-               \n{}{} you can also use the `{}` mips instruction in your program's code!",
-                 "tip".yellow().bold(),
-                 ":".bold(),
-                 "break".bold(),
-            ),
-        );
-    }
-
+fn breakpoint_list(state: &State) -> Result<String, CommandError> {
     let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
 
     if binary.breakpoints.is_empty() {
@@ -393,34 +392,9 @@ fn breakpoint_list(state: &State, label: &str) -> Result<String, CommandError> {
 
 fn breakpoint_toggle(
     state: &mut State,
-    label: &str,
     args: &[String],
     op: EnableOp,
 ) -> Result<String, CommandError> {
-    if label == "__help__" {
-        return Ok(
-            format!(
-                "Usage: {8} {9} {3}\n\
-                 {0}s, {1}s, or {2}s a breakpoint at the specified {3}.\n\
-                 {3} may be: a decimal address (`4194304`), a hex address (`{4}400000`),\n\
-        \x20                 a label (`{5}`), a line number (`:14`, `prog.s:7`), or an id (`{6}`).\n\
-                 Breakpoints that are disabled do not trigger when they are hit.\n\
-                 Breakpoints caused by the `{7}` instruction in code cannot be disabled.
-                ",
-                "<enable>".purple(),
-                "<disable>".purple(),
-                "<toggle>".purple(),
-                "<address>".purple(),
-                "0x".yellow(),
-                "main".yellow().bold(),
-                "!3".blue(),
-                "break".bold(),
-                "breakpoint".yellow().bold(),
-                "{enable, disable, toggle}".purple(),
-            )
-        );
-    }
-
     if args.is_empty() {
         return Err(generate_err(
             CommandError::MissingArguments {
@@ -504,33 +478,7 @@ fn breakpoint_toggle(
     Ok("".into())
 }
 
-fn breakpoint_ignore(
-    state: &mut State,
-    label: &str,
-    args: &[String],
-) -> Result<String, CommandError> {
-    if label == "__help__" {
-        return Ok(
-            format!(
-                "Usage: {6} {7} {1} {0}\n\
-                 {7}s a breakpoint at the specified {1} for the next {0} hits.\n\
-                 {1} may be: a decimal address (`4194304`), a hex address (`{2}400000`),\n\
-        \x20                 a label (`{3}`), a line number (`:14`, `prog.s:7`), or an id (`{4}`).\n\
-                 Breakpoints that are ignored do not trigger when they are hit.\n\
-                 Breakpoints caused by the `{5}` instruction in code cannot ignored.
-                ",
-                "<ignore count>".purple(),
-                "<address>".purple(),
-                "0x".yellow(),
-                "main".yellow().bold(),
-                "!3".blue(),
-                "break".bold(),
-                "breakpoint".yellow().bold(),
-                "ignore".purple(),
-            )
-        );
-    }
-
+fn breakpoint_ignore(state: &mut State, args: &[String]) -> Result<String, CommandError> {
     if args.is_empty() {
         return Err(generate_err(
             CommandError::MissingArguments {
@@ -593,28 +541,7 @@ fn breakpoint_ignore(
     Ok("".into())
 }
 
-fn breakpoint_commands(
-    state: &mut State,
-    label: &str,
-    args: &[String],
-) -> Result<String, CommandError> {
-    if label == "__help__" {
-        return Ok(format!(
-            "Takes in a list of commands seperated by newlines,\n\
-                 and attaches the commands to the specified {0}.\n\
-                 If no breakpoint is specified, the most recently created breakpoint is chosen.\n\
-                 Whenever that breakpoint is hit, the commands will automatically be executed\n\
-                 in the provided order.\n\
-                 The list of commands can be ended using the {1} command, EOF, or an empty line.\n\
-                 To view the commands attached to a particular breakpoint,\n\
-                 use {2} {0}
-                ",
-            "<breakpoint id>".purple(),
-            "end".yellow().bold(),
-            "commands list".bold().yellow(),
-        ));
-    }
-
+fn breakpoint_commands(state: &mut State, args: &[String]) -> Result<String, CommandError> {
     let binary = state.binary.as_mut().ok_or(CommandError::MustLoadFile)?;
     state.confirm_exit = true;
     handle_commands(args, &mut binary.breakpoints)
@@ -720,4 +647,58 @@ fn parse_breakpoint_arg(state: &State, arg: &String) -> Result<(u32, MipsyArgTyp
     } else {
         Err(get_error("<addr>"))
     }
+}
+
+fn breakpoint_insert_help() -> String {
+    format!(
+        "Usage: {10} {11} {2}\n\
+        {0}s or {1}s a breakpoint at the specified {2}.\n\
+        {2} may be: a decimal address (`4194304`), a hex address (`{3}400000`),\n\
+        \x20             a label (`{4}`), or a line number (`:14`, `prog.s:7`).\n\
+        If you are removing a breakpoint, you can also use its id (`{5}`).\n\
+        {6} must be `i`, `in`, `ins`, `insert`, or `add` to insert the breakpoint, or\n\
+        \x20             `del`, `delete`, `rm` or `remove` to remove the breakpoint.\n\
+        If {12}, `tmp`, or `temp` is provided as the {6}, the breakpoint will\n\
+        be created as a temporary breakpoint, which automatically deletes itself after being hit.\n\
+        If {6} is none of these option, it defaults to inserting a breakpoint at {6}.\n\
+        When running or stepping through your program, a breakpoint will cause execution to\n\
+        pause temporarily, allowing you to debug the current state.\n\
+        May error if provided a label that doesn't exist.\n\
+        \n{7}{8} you can also use the `{9}` MIPS instruction in your program's code!",
+        "<insert>".magenta(),
+        "<delete>".magenta(),
+        "<address>".magenta(),
+        "0x".yellow(),
+        "main".yellow().bold(),
+        "!3".blue(),
+        "<subcommand>".magenta(),
+        "tip".yellow().bold(),
+        ":".bold(),
+        "break".bold(),
+        "breakpoint".yellow().bold(),
+        "{insert, delete, temporary}".purple(),
+        "<temporary>".purple(),
+    )
+}
+
+fn breakpoint_toggle_help() -> String {
+    format!(
+        "Usage: {8} {9} {3}\n\
+        {0}s, {1}s, or {2}s a breakpoint at the specified {3}.\n\
+        {3} may be: a decimal address (`4194304`), a hex address (`{4}400000`),\n\
+        \x20                 a label (`{5}`), a line number (`:14`, `prog.s:7`), or an id (`{6}`).\n\
+        Breakpoints that are disabled do not trigger when they are hit.\n\
+        Breakpoints caused by the `{7}` instruction in code cannot be disabled.
+        ",
+        "<enable>".purple(),
+        "<disable>".purple(),
+        "<toggle>".purple(),
+        "<address>".purple(),
+        "0x".yellow(),
+        "main".yellow().bold(),
+        "!3".blue(),
+        "break".bold(),
+        "breakpoint".yellow().bold(),
+        "{enable, disable, toggle}".purple(),
+    )
 }

--- a/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/breakpoint.rs
@@ -39,9 +39,7 @@ pub(crate) fn command() -> Command {
             "manage breakpoints ({} to list subcommands)",
             "help breakpoint".bold()
         ))
-        .with_optional_arg(Argument::new("subcommand", |a| {
-            Ok(ArgumentKind::Any(a.to_owned()))
-        }))
+        .with_optional_arg(Argument::subcommands())
         .with_subcommand(
             Command::new()
                 .with_name("list")

--- a/crates/mipsy_interactive/src/interactive/commands/commands.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/commands.rs
@@ -73,35 +73,35 @@ fn add_commands<K, V: Point>(points: &mut HashMap<K, V>, id: u32) -> CommandResu
         "end".bold().yellow()
     );
 
-    let mut rl = editor(&[]);
-    loop {
-        let readline = rl.readline("");
-
-        match readline {
-            Ok(line) => {
-                if line.is_empty() || line == "\n" || line == "end" {
-                    break;
-                }
-
-                commands.push(line);
-            }
-            Err(ReadlineError::Interrupted) => {
-                std::process::exit(0);
-            }
-            Err(ReadlineError::Eof) => {
-                break;
-            }
-            Err(err) => {
-                println!("Error: {:?}", err);
-                break;
-            }
-        }
-    }
-
-    prompt::success_nl(format!(
-        "commands attached to breakpoint {}",
-        format!("!{id}").blue()
-    ));
+    // let mut rl = editor(state);
+    // loop {
+    //     let readline = rl.readline("");
+    //
+    //     match readline {
+    //         Ok(line) => {
+    //             if line.is_empty() || line == "\n" || line == "end" {
+    //                 break;
+    //             }
+    //
+    //             commands.push(line);
+    //         }
+    //         Err(ReadlineError::Interrupted) => {
+    //             std::process::exit(0);
+    //         }
+    //         Err(ReadlineError::Eof) => {
+    //             break;
+    //         }
+    //         Err(err) => {
+    //             println!("Error: {:?}", err);
+    //             break;
+    //         }
+    //     }
+    // }
+    //
+    // prompt::success_nl(format!(
+    //     "commands attached to breakpoint {}",
+    //     format!("!{id}").blue()
+    // ));
     Ok("".into())
 }
 

--- a/crates/mipsy_interactive/src/interactive/commands/commands.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/commands.rs
@@ -2,12 +2,8 @@ use std::collections::HashMap;
 
 use colored::Colorize;
 use mipsy_lib::compile::breakpoints::Point;
-use rustyline::error::ReadlineError;
 
-use crate::{
-    interactive::{editor, error::CommandError},
-    prompt,
-};
+use crate::{interactive::error::CommandError, prompt};
 
 use super::*;
 

--- a/crates/mipsy_interactive/src/interactive/commands/commands.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/commands.rs
@@ -73,7 +73,7 @@ fn add_commands<K, V: Point>(points: &mut HashMap<K, V>, id: u32) -> CommandResu
         "end".bold().yellow()
     );
 
-    let mut rl = editor();
+    let mut rl = editor(&[]);
     loop {
         let readline = rl.readline("");
 

--- a/crates/mipsy_interactive/src/interactive/commands/context.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/context.rs
@@ -6,18 +6,25 @@ use mipsy_lib::KTEXT_BOT;
 use mipsy_lib::TEXT_BOT;
 
 #[allow(unreachable_code)]
-pub(crate) fn context_command() -> Command {
-    command(
-        "context",
-        vec!["c", "ctx"],
-        vec![],
-        vec!["n"],
-        vec![],
-        &format!(
+pub(crate) fn command() -> Command {
+    Command::new()
+        .with_name("context")
+        .with_name("c")
+        .with_name("ctx")
+        .with_exact_args()
+        .with_optional_arg(Argument::new("n", |a| {
+            Ok(ArgumentKind::Number(expect_u32(
+                "",
+                &"[n]".bright_magenta(),
+                a,
+                None as Option<&dyn Fn(i32) -> String>,
+            )? as _))
+        }))
+        .with_desc(format!(
             "prints the current and surrounding 3 (or {}) instructions",
             "[n]".magenta(),
-        ),
-        |_, state, label, args| {
+        ))
+        .with_exec(|_, state, label, args| {
             if label == "__help__" {
                 return Ok(format!(
                     "prints the current and surrounding 3 (or {}) instructions",
@@ -25,12 +32,11 @@ pub(crate) fn context_command() -> Command {
                 ));
             }
 
-            let f: Option<&dyn Fn(i32) -> String> = None;
-
             let n = match args.first() {
-                Some(arg) => expect_u32(label, &"[n]".bright_magenta(), arg, f),
-                None => Ok(3),
-            }? as i32;
+                Some(ArgumentKind::Number(a)) => *a as _,
+                None => 3,
+                _ => unreachable!(),
+            };
 
             if state.exited {
                 return Err(CommandError::ProgramExited);
@@ -69,6 +75,5 @@ pub(crate) fn context_command() -> Command {
 
             println!();
             Ok("".into())
-        },
-    )
+        })
 }

--- a/crates/mipsy_interactive/src/interactive/commands/context.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/context.rs
@@ -28,14 +28,11 @@ pub(crate) fn command() -> Command {
             "prints the current and surrounding 3 (or {}) instructions",
             "[n]".magenta(),
         ))
-        .with_exec(|_, state, _, label, args| {
-            if label == "__help__" {
-                return Ok(format!(
-                    "prints the current and surrounding 3 (or {}) instructions",
-                    "[n]".magenta(),
-                ));
-            }
-
+        .with_help(format!(
+            "prints the current and surrounding 3 (or {}) instructions",
+            "[n]".magenta(),
+        ))
+        .with_exec(|_, state, _, args| {
             let n = match args.first() {
                 Some(ArgumentKind::Number(a)) => *a as _,
                 None => 3,

--- a/crates/mipsy_interactive/src/interactive/commands/context.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/context.rs
@@ -12,14 +12,18 @@ pub(crate) fn command() -> Command {
         .with_name("c")
         .with_name("ctx")
         .with_exact_args()
-        .with_optional_arg(Argument::new("n", |a| {
-            Ok(ArgumentKind::Number(expect_u32(
-                "",
-                &"[n]".bright_magenta(),
-                a,
-                None as Option<&dyn Fn(i32) -> String>,
-            )? as _))
-        }))
+        .with_optional_arg(Argument::new(
+            "n",
+            |a| {
+                Ok(ArgumentKind::Number(expect_u32(
+                    "",
+                    &"[n]".bright_magenta(),
+                    a,
+                    None as Option<&dyn Fn(i32) -> String>,
+                )? as _))
+            },
+            |_, _| vec![],
+        ))
         .with_desc(format!(
             "prints the current and surrounding 3 (or {}) instructions",
             "[n]".magenta(),

--- a/crates/mipsy_interactive/src/interactive/commands/context.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/context.rs
@@ -14,7 +14,7 @@ pub(crate) fn command() -> Command {
         .with_exact_args()
         .with_optional_arg(Argument::new(
             "n",
-            |a| {
+            |a, _| {
                 Ok(ArgumentKind::Number(expect_u32(
                     "",
                     &"[n]".bright_magenta(),
@@ -28,7 +28,7 @@ pub(crate) fn command() -> Command {
             "prints the current and surrounding 3 (or {}) instructions",
             "[n]".magenta(),
         ))
-        .with_exec(|_, state, label, args| {
+        .with_exec(|_, state, _, label, args| {
             if label == "__help__" {
                 return Ok(format!(
                     "prints the current and surrounding 3 (or {}) instructions",

--- a/crates/mipsy_interactive/src/interactive/commands/context.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/context.rs
@@ -14,7 +14,7 @@ pub(crate) fn command() -> Command {
         .with_exact_args()
         .with_optional_arg(Argument::new(
             "n",
-            |_, a, _| {
+            |a, _| {
                 Ok(ArgumentKind::Number(expect_u32(
                     "",
                     &"[n]".bright_magenta(),
@@ -22,7 +22,7 @@ pub(crate) fn command() -> Command {
                     None as Option<&dyn Fn(i32) -> String>,
                 )? as _))
             },
-            |_, _, _| vec![],
+            |_, _| vec![],
         ))
         .with_desc(format!(
             "prints the current and surrounding 3 (or {}) instructions",
@@ -33,7 +33,12 @@ pub(crate) fn command() -> Command {
             "[n]".magenta(),
         ))
         .with_exec(|_, helper, args| {
-            let n = args.first().cloned().map(i64::from).or(Some(3)).unwrap();
+            let n = args
+                .first()
+                .cloned()
+                .map(|a| i64::try_from(a).unwrap())
+                .or(Some(3))
+                .unwrap();
 
             if helper.state.exited {
                 return Err(CommandError::ProgramExited);

--- a/crates/mipsy_interactive/src/interactive/commands/context.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/context.rs
@@ -14,7 +14,7 @@ pub(crate) fn command() -> Command {
         .with_exact_args()
         .with_optional_arg(Argument::new(
             "n",
-            |a, _| {
+            |_, a, _| {
                 Ok(ArgumentKind::Number(expect_u32(
                     "",
                     &"[n]".bright_magenta(),
@@ -22,7 +22,7 @@ pub(crate) fn command() -> Command {
                     None as Option<&dyn Fn(i32) -> String>,
                 )? as _))
             },
-            |_, _| vec![],
+            |_, _, _| vec![],
         ))
         .with_desc(format!(
             "prints the current and surrounding 3 (or {}) instructions",

--- a/crates/mipsy_interactive/src/interactive/commands/context.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/context.rs
@@ -32,23 +32,27 @@ pub(crate) fn command() -> Command {
             "prints the current and surrounding 3 (or {}) instructions",
             "[n]".magenta(),
         ))
-        .with_exec(|_, state, _, args| {
-            let n = match args.first() {
-                Some(ArgumentKind::Number(a)) => *a as _,
-                None => 3,
-                _ => unreachable!(),
-            };
+        .with_exec(|_, helper, args| {
+            let n = args.first().cloned().map(i64::from).or(Some(3)).unwrap();
 
-            if state.exited {
+            if helper.state.exited {
                 return Err(CommandError::ProgramExited);
             }
 
-            let program = state.program.as_ref().ok_or(CommandError::MustLoadFile)?;
-            let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
-            let runtime = &state.runtime;
+            let program = helper
+                .state
+                .program
+                .as_ref()
+                .ok_or(CommandError::MustLoadFile)?;
+            let binary = helper
+                .state
+                .binary
+                .as_ref()
+                .ok_or(CommandError::MustLoadFile)?;
+            let runtime = &helper.state.runtime;
 
             let base_addr = runtime.timeline().state().pc();
-            for i in (-n)..=n {
+            for i in (-n)..n {
                 let addr = {
                     let addr = base_addr.wrapping_add((i * 4) as u32);
                     if addr < TEXT_BOT {
@@ -70,7 +74,8 @@ pub(crate) fn command() -> Command {
                     }
                 };
 
-                let parts = decompile::decompile_inst_into_parts(binary, &state.iset, inst, addr);
+                let parts =
+                    decompile::decompile_inst_into_parts(binary, &helper.state.iset, inst, addr);
                 util::print_inst_parts(binary, &Ok(parts), Some(program), i == 0);
             }
 

--- a/crates/mipsy_interactive/src/interactive/commands/disassemble.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/disassemble.rs
@@ -19,10 +19,14 @@ pub(crate) fn command() -> Command {
             "Disassembles the currently loaded file, similar to how `{}` displays instructions.",
             "step".bold(),
         ))
-        .with_exec(|_, state, _, _| {
-            let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
+        .with_exec(|_, helper, _| {
+            let binary = helper
+                .state
+                .binary
+                .as_ref()
+                .ok_or(CommandError::MustLoadFile)?;
 
-            let mut decompiled = decompile_into_parts(binary, &state.iset)
+            let mut decompiled = decompile_into_parts(binary, &helper.state.iset)
                 .into_iter()
                 .collect::<Vec<(u32, Result<Decompiled, Uninit>)>>();
 
@@ -40,7 +44,7 @@ pub(crate) fn command() -> Command {
             }
 
             for (_, inst) in decompiled {
-                util::print_inst_parts(binary, &inst, state.program.as_deref(), false);
+                util::print_inst_parts(binary, &inst, helper.state.program.as_deref(), false);
             }
 
             println!();

--- a/crates/mipsy_interactive/src/interactive/commands/disassemble.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/disassemble.rs
@@ -5,15 +5,17 @@ use colored::*;
 
 use mipsy_lib::decompile::{decompile_into_parts, Decompiled, Uninit};
 
-pub(crate) fn disassemble_command() -> Command {
-    command(
-        "disassemble",
-        vec!["d", "dis", "disas", "disasm", "dec", "decompile"],
-        vec![],
-        vec![],
-        vec![],
-        "disassembles the currently loaded file",
-        |_, state, label, _args| {
+pub(crate) fn command() -> Command {
+    Command::new()
+        .with_name("disassemble")
+        .with_name("d")
+        .with_name("dis")
+        .with_name("disas")
+        .with_name("disasm")
+        .with_name("dec")
+        .with_name("decompile")
+        .with_desc("disassembles the currently loaded file")
+        .with_exec(|_, state, label, _| {
             if label == "__help__" {
                 return Ok(
                     format!(

--- a/crates/mipsy_interactive/src/interactive/commands/disassemble.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/disassemble.rs
@@ -15,16 +15,11 @@ pub(crate) fn command() -> Command {
         .with_name("dec")
         .with_name("decompile")
         .with_desc("disassembles the currently loaded file")
-        .with_exec(|_, state, _, label, _| {
-            if label == "__help__" {
-                return Ok(
-                    format!(
-                        "Disassembles the currently loaded file, similar to how `{}` displays instructions.",
-                        "step".bold(),
-                    ),
-                );
-            }
-
+        .with_help(format!(
+            "Disassembles the currently loaded file, similar to how `{}` displays instructions.",
+            "step".bold(),
+        ))
+        .with_exec(|_, state, _, _| {
             let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
 
             let mut decompiled = decompile_into_parts(binary, &state.iset)
@@ -51,6 +46,5 @@ pub(crate) fn command() -> Command {
             println!();
 
             Ok("".into())
-        },
-    )
+        })
 }

--- a/crates/mipsy_interactive/src/interactive/commands/disassemble.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/disassemble.rs
@@ -15,7 +15,7 @@ pub(crate) fn command() -> Command {
         .with_name("dec")
         .with_name("decompile")
         .with_desc("disassembles the currently loaded file")
-        .with_exec(|_, state, label, _| {
+        .with_exec(|_, state, _, label, _| {
             if label == "__help__" {
                 return Ok(
                     format!(

--- a/crates/mipsy_interactive/src/interactive/commands/dot.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/dot.rs
@@ -1,5 +1,5 @@
 use colored::Colorize;
-use mipsy_lib::Binary;
+use mipsy_lib::inst::{InstSignature, PseudoSignature};
 use std::rc::Rc;
 
 use mipsy_lib::{compile, MpProgram};
@@ -9,28 +9,42 @@ use crate::interactive::{commands::watchpoint::args_text, error::CommandError};
 
 use super::*;
 
+fn instruction_names(h: &MyHelper) -> Vec<String> {
+    h.state
+        .iset
+        .native_set()
+        .iter()
+        .map(InstSignature::name)
+        .chain(h.state.iset.pseudo_set().iter().map(PseudoSignature::name))
+        .map(str::to_owned)
+        .collect()
+}
+
 pub(crate) fn command() -> Command {
     Command::new()
         .with_name(".")
         .with_desc("execute a MIPS instruction")
         .with_var_args()
-        // TODO: context for hints and sanitisation
         .with_required_arg(Argument::new(
             "instruction",
-            |_, a, _| Ok(ArgumentKind::String(a.to_owned())),
-            |_, _, _| vec![],
+            |_, a, h| match instruction_names(h).contains(&a.to_owned()) {
+                true => Ok(ArgumentKind::String(a.to_owned())),
+                false => Err(CommandError::BadArgument {
+                    arg: "instruction".to_owned(),
+                    instead: a.to_owned(),
+                }),
+            },
+            |_, _, h| instruction_names(h),
         ))
         .with_help("Executes a MIPS instruction immediately".to_owned())
         .with_varargs_format("{args}".magenta().to_string())
-        .with_exec(|_, state, helper, args| {
+        .with_exec(|_, helper, args| {
             let line = args_text(args).join(" ");
 
-            let inst =
-                mipsy_parser::parse_instruction(&line, state.config.tab_size).map_err(|error| {
-                    CommandError::CannotParseLine {
-                        line: line.to_string(),
-                        error,
-                    }
+            let inst = mipsy_parser::parse_instruction(&line, helper.state.config.tab_size)
+                .map_err(|error| CommandError::CannotParseLine {
+                    line: line.to_string(),
+                    error,
                 })?;
 
             let program = MpProgram::new(
@@ -48,8 +62,11 @@ pub(crate) fn command() -> Command {
                 error,
             })?;
 
-            let empty_binary = Binary::default();
-            let binary = state.binary.as_ref().unwrap_or(&empty_binary);
+            let binary = helper
+                .state
+                .binary
+                .as_ref()
+                .ok_or(CommandError::MustLoadFile)?;
 
             compile::check_post_data_label(&program, binary).map_err(|error| {
                 CommandError::CannotCompileLine {
@@ -58,7 +75,7 @@ pub(crate) fn command() -> Command {
                 }
             })?;
 
-            let opcodes = mipsy_lib::compile1(binary, &state.iset, &inst)
+            let opcodes = mipsy_lib::compile1(binary, &helper.state.iset, &inst)
                 .map_err(|error| {
                     error.into_compiler_mipsy_error(Rc::from(""), 1, inst.col(), inst.col_end())
                 })
@@ -68,7 +85,7 @@ pub(crate) fn command() -> Command {
                 })?;
 
             for opcode in opcodes {
-                state.exec_inst(opcode, true, helper).map_err(|err| {
+                State::exec_inst(helper, opcode, true).map_err(|err| {
                     let mipsy_error = match err {
                         CommandError::RuntimeError { mipsy_error } => mipsy_error,
                         _ => unreachable!(),

--- a/crates/mipsy_interactive/src/interactive/commands/dot.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/dot.rs
@@ -14,9 +14,12 @@ pub(crate) fn command() -> Command {
         .with_name(".")
         .with_desc("execute a MIPS instruction")
         .with_var_args()
-        .with_required_arg(Argument::new("instruction", |a| {
-            Ok(ArgumentKind::Any(a.to_owned()))
-        }))
+        // TODO: context for hints and sanitisation
+        .with_required_arg(Argument::new(
+            "instruction",
+            |a| Ok(ArgumentKind::Any(a.to_owned())),
+            |_, _| vec![],
+        ))
         .with_varargs_format("{args}".magenta().to_string())
         .with_exec(|_, state, label, args| {
             if label == "__help__" {

--- a/crates/mipsy_interactive/src/interactive/commands/dot.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/dot.rs
@@ -20,12 +20,9 @@ pub(crate) fn command() -> Command {
             |a, _| Ok(ArgumentKind::String(a.to_owned())),
             |_, _| vec![],
         ))
+        .with_help("Executes a MIPS instruction immediately".to_owned())
         .with_varargs_format("{args}".magenta().to_string())
-        .with_exec(|_, state, helper, label, args| {
-            if label == "__help__" {
-                return Ok("Executes a MIPS instruction immediately".into());
-            }
-
+        .with_exec(|_, state, helper, args| {
             let line = args_text(args).join(" ");
 
             let inst =

--- a/crates/mipsy_interactive/src/interactive/commands/dot.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/dot.rs
@@ -17,20 +17,16 @@ pub(crate) fn command() -> Command {
         // TODO: context for hints and sanitisation
         .with_required_arg(Argument::new(
             "instruction",
-            |a| Ok(ArgumentKind::Any(a.to_owned())),
+            |a, _| Ok(ArgumentKind::String(a.to_owned())),
             |_, _| vec![],
         ))
         .with_varargs_format("{args}".magenta().to_string())
-        .with_exec(|_, state, label, args| {
+        .with_exec(|_, state, helper, label, args| {
             if label == "__help__" {
                 return Ok("Executes a MIPS instruction immediately".into());
             }
 
-            let line = args_text(args)
-                .iter()
-                .map(|&a| a.clone())
-                .collect::<Vec<_>>()
-                .join(" ");
+            let line = args_text(args).join(" ");
 
             let inst =
                 mipsy_parser::parse_instruction(&line, state.config.tab_size).map_err(|error| {
@@ -75,7 +71,7 @@ pub(crate) fn command() -> Command {
                 })?;
 
             for opcode in opcodes {
-                state.exec_inst(opcode, true).map_err(|err| {
+                state.exec_inst(opcode, true, helper).map_err(|err| {
                     let mipsy_error = match err {
                         CommandError::RuntimeError { mipsy_error } => mipsy_error,
                         _ => unreachable!(),

--- a/crates/mipsy_interactive/src/interactive/commands/dot.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/dot.rs
@@ -5,24 +5,29 @@ use std::rc::Rc;
 use mipsy_lib::{compile, MpProgram};
 use mipsy_parser::{parser::MpAttributedItem, MpItem};
 
-use crate::interactive::error::CommandError;
+use crate::interactive::{commands::watchpoint::args_text, error::CommandError};
 
 use super::*;
 
-pub(crate) fn dot_command() -> Command {
-    command_varargs(
-        ".",
-        vec![],
-        vec!["instruction"],
-        "{args}".magenta().to_string(),
-        vec![],
-        "execute a MIPS instruction",
-        |_, state, label, args| {
+pub(crate) fn command() -> Command {
+    Command::new()
+        .with_name(".")
+        .with_desc("execute a MIPS instruction")
+        .with_var_args()
+        .with_required_arg(Argument::new("instruction", |a| {
+            Ok(ArgumentKind::Any(a.to_owned()))
+        }))
+        .with_varargs_format("{args}".magenta().to_string())
+        .with_exec(|_, state, label, args| {
             if label == "__help__" {
                 return Ok("Executes a MIPS instruction immediately".into());
             }
 
-            let line = args.join(" ");
+            let line = args_text(args)
+                .iter()
+                .map(|&a| a.clone())
+                .collect::<Vec<_>>()
+                .join(" ");
 
             let inst =
                 mipsy_parser::parse_instruction(&line, state.config.tab_size).map_err(|error| {
@@ -81,6 +86,5 @@ pub(crate) fn dot_command() -> Command {
             }
 
             Ok("".into())
-        },
-    )
+        })
 }

--- a/crates/mipsy_interactive/src/interactive/commands/dot.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/dot.rs
@@ -27,14 +27,14 @@ pub(crate) fn command() -> Command {
         .with_var_args(Argument::from_name("{args}".magenta().to_string()))
         .with_required_arg(Argument::new(
             "instruction",
-            |_, a, h| match instruction_names(h).contains(&a.to_owned()) {
+            |a, h| match instruction_names(h).contains(&a.to_owned()) {
                 true => Ok(ArgumentKind::String(a.to_owned())),
                 false => Err(CommandError::BadArgument {
                     arg: "instruction".to_owned(),
                     instead: a.to_owned(),
                 }),
             },
-            |_, _, h| instruction_names(h),
+            |_, h| instruction_names(h),
         ))
         .with_help("Executes a MIPS instruction immediately".to_owned())
         .with_exec(|_, helper, args| {

--- a/crates/mipsy_interactive/src/interactive/commands/dot.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/dot.rs
@@ -17,8 +17,8 @@ pub(crate) fn command() -> Command {
         // TODO: context for hints and sanitisation
         .with_required_arg(Argument::new(
             "instruction",
-            |a, _| Ok(ArgumentKind::String(a.to_owned())),
-            |_, _| vec![],
+            |_, a, _| Ok(ArgumentKind::String(a.to_owned())),
+            |_, _, _| vec![],
         ))
         .with_help("Executes a MIPS instruction immediately".to_owned())
         .with_varargs_format("{args}".magenta().to_string())

--- a/crates/mipsy_interactive/src/interactive/commands/dot.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/dot.rs
@@ -24,9 +24,7 @@ pub(crate) fn command() -> Command {
     Command::new()
         .with_name(".")
         .with_desc("execute a MIPS instruction")
-        .with_var_args(Argument::from_name(
-            "{args}".magenta().to_string()
-        ))
+        .with_var_args(Argument::from_name("{args}".magenta().to_string()))
         .with_required_arg(Argument::new(
             "instruction",
             |_, a, h| match instruction_names(h).contains(&a.to_owned()) {

--- a/crates/mipsy_interactive/src/interactive/commands/dot.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/dot.rs
@@ -24,7 +24,9 @@ pub(crate) fn command() -> Command {
     Command::new()
         .with_name(".")
         .with_desc("execute a MIPS instruction")
-        .with_var_args()
+        .with_var_args(Argument::from_name(
+            "{args}".magenta().to_string()
+        ))
         .with_required_arg(Argument::new(
             "instruction",
             |_, a, h| match instruction_names(h).contains(&a.to_owned()) {
@@ -37,7 +39,6 @@ pub(crate) fn command() -> Command {
             |_, _, h| instruction_names(h),
         ))
         .with_help("Executes a MIPS instruction immediately".to_owned())
-        .with_varargs_format("{args}".magenta().to_string())
         .with_exec(|_, helper, args| {
             let line = args_text(args).join(" ");
 

--- a/crates/mipsy_interactive/src/interactive/commands/examine.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/examine.rs
@@ -19,10 +19,11 @@ pub(crate) fn command() -> Command {
         .with_name("dump")
         .with_desc("examine memory contents")
         .with_exact_args()
-        .with_optional_arg(Argument::new("section", |a| Ok(ArgumentKind::Any(a.to_owned()))))
-        .with_optional_arg(Argument::new("len", |a| Ok(ArgumentKind::Any(a.to_owned()))))
-        .with_optional_arg(Argument::new("addr", |a| Ok(ArgumentKind::Any(a.to_owned()))))
-        .with_optional_arg(Argument::new("-nolabels", |a| Ok(ArgumentKind::Any(a.to_owned()))))
+        // TODO: again, get a context to sanitise and hint this
+        .with_optional_arg(Argument::new("section", |a| Ok(ArgumentKind::Any(a.to_owned())), |_, _| vec![]))
+        .with_optional_arg(Argument::new("len", |a| Ok(ArgumentKind::Any(a.to_owned())), |_, _| vec![]))
+        .with_optional_arg(Argument::new("addr", |a| Ok(ArgumentKind::Any(a.to_owned())), |_, _| vec![]))
+        .with_optional_arg(Argument::new("-nolabels", |a| Ok(ArgumentKind::Any(a.to_owned())), |_, _| vec![]))
         .with_exec(
         |_, state, label, args| {
             let mut args = &args_text(args)[..];

--- a/crates/mipsy_interactive/src/interactive/commands/examine.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/examine.rs
@@ -24,188 +24,185 @@ pub(crate) fn command() -> Command {
         .with_optional_arg(Argument::new("len", |a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _| vec![]))
         .with_optional_arg(Argument::new("addr", |a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _| vec![]))
         .with_optional_arg(Argument::new("-nolabels", |a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _| vec![]))
-        .with_exec(
-        |_, state, _, label, args| {
-            let mut args = &args_text(args)[..];
-            // TODO: <enter> to examine the next chunk of memory
-            if label == "__help__" {
-                return Ok(
-                    format!(
-                        "Examine memory contents in a format akin to the tool `xxd`.\n\
-                         {0} may be: `.data` (default), `.text`, `.stack`, `.kdata`, `.ktext`.\n\
-                         {1} controls the maximum number of bytes displayed.\n\
-                         {2} controls where the memory dump starts (by default the start of the section).\n\
-                         {2} may be: a register name (`$t0`, `t0`), a register number (`$14`, 14),\n\
-                    \x20             a decimal address (`4194304`), a hex address (`{3}400000`),\n\
-                    \x20             or a label (`{4}`).\n\
-                         If {7} is provided, then label names will be included in the output.\n\
-                         Unprintable bytes are displayed as {5}, and uninitialized bytes are displayed as {6}.\n\
-                        ",
-                        "<section>".magenta(),
-                        "<length>".magenta(),
-                        "<addr>".magenta(),
-                        "0x".yellow(),
-                        "main".yellow().bold(),
-                        ".".bright_black(),
-                        "_".bright_black(),
-                        "-nolabels".magenta(),
-                    )
-                );
-            }
+        .with_help(
+            format!(
+                "Examine memory contents in a format akin to the tool `xxd`.\n\
+                {0} may be: `.data` (default), `.text`, `.stack`, `.kdata`, `.ktext`.\n\
+                {1} controls the maximum number of bytes displayed.\n\
+                {2} controls where the memory dump starts (by default the start of the section).\n\
+                {2} may be: a register name (`$t0`, `t0`), a register number (`$14`, 14),\n\
+                \x20             a decimal address (`4194304`), a hex address (`{3}400000`),\n\
+                \x20             or a label (`{4}`).\n\
+                If {7} is provided, then label names will be included in the output.\n\
+                Unprintable bytes are displayed as {5}, and uninitialized bytes are displayed as {6}.\n\
+                ",
+                "<section>".magenta(),
+                "<length>".magenta(),
+                "<addr>".magenta(),
+                "0x".yellow(),
+                "main".yellow().bold(),
+                ".".bright_black(),
+                "_".bright_black(),
+                "-nolabels".magenta(),
+            )
+            )
+            .with_exec(
+                |_, state, _, args| {
+                    let mut args = &args_text(args)[..];
+                    // TODO: <enter> to examine the next chunk of memory
+                    let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
 
-            let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
+                    let mut segment = if let Some(segment) =
+                        args.get(0).and_then(|segment| match segment.as_ref() {
+                            ".data" => Some(Segment::Data),
+                            ".text" => Some(Segment::Text),
+                            ".stack" => Some(Segment::Stack),
+                            ".kdata" => Some(Segment::KData),
+                            ".ktext" => Some(Segment::KText),
+                            _ => None,
+                        }) {
+                            args = &args[1..];
+                            segment
+                        } else {
+                            Segment::Data
+                        };
 
-            let mut segment = if let Some(segment) =
-                args.get(0).and_then(|segment| match segment.as_ref() {
-                    ".data" => Some(Segment::Data),
-                    ".text" => Some(Segment::Text),
-                    ".stack" => Some(Segment::Stack),
-                    ".kdata" => Some(Segment::KData),
-                    ".ktext" => Some(Segment::KText),
-                    _ => None,
-                }) {
-                args = &args[1..];
-                segment
-            } else {
-                Segment::Data
-            };
+                    let dump_len = if let Some(len) = args.get(0).and_then(|num| num.parse::<usize>().ok())
+                    {
+                        args = &args[1..];
+                        len
+                    } else {
+                        128
+                    };
 
-            let dump_len = if let Some(len) = args.get(0).and_then(|num| num.parse::<usize>().ok())
-            {
-                args = &args[1..];
-                len
-            } else {
-                128
-            };
+                    let mut base_addr = if let Some(base) = args.get(0).map(|arg| parse_arg(state, arg)) {
+                        if base.is_ok() {
+                            args = &args[1..];
+                        }
+                        base
+                    } else {
+                        Ok(segment.get_lower_bound())
+                    };
 
-            let mut base_addr = if let Some(base) = args.get(0).map(|arg| parse_arg(state, arg)) {
-                if base.is_ok() {
-                    args = &args[1..];
-                }
-                base
-            } else {
-                Ok(segment.get_lower_bound())
-            };
-
-            let hide_labels = args
-                .get(0)
-                .map_or(false, |a| a == "-nolabels");
-            if hide_labels && base_addr.is_err() {
-                // if -labels was provided, ensure base_addr is valid
-                base_addr = Ok(segment.get_lower_bound());
-            }
-
-            let base_addr = base_addr? as usize;
-
-            // for most cases this is a no-op, but if given an address in the stack we should
-            // reverse the order of the scan
-            segment = get_segment(base_addr as u32);
-
-            let default_size = 16;
-            let row_size: usize = termsize::get()
-                .map_or(default_size, |size|
-                // subtract "0x{:8x}: " length and allow for extra length in representation
-                // TODO: allow rows longer than 16 bytes? can be done by removing .min() but not very readable
-                (((size.cols - 12 - 1) * 2 / 7) as usize).min(default_size))
-                .max(1);
-
-            let mut rows: usize = dump_len / row_size;
-            if dump_len % row_size != 0 {
-                rows += 1;
-            }
-            let offset: usize = row_size * 5 / 2;
-
-            for nth in 0..rows {
-                let mut label_strs: Vec<WrappedString> = Vec::new();
-                let mut arrow_tips = WrappedString::new();
-                let mut byte_repr = String::with_capacity(row_size * 3);
-                let mut printable_repr = String::with_capacity(row_size);
-
-                for offset in 0..row_size {
-                    // print in groups of 2 (`xxd` format)
-                    if offset % 2 == 0 {
-                        byte_repr.push(' ');
+                    let hide_labels = args
+                        .get(0)
+                        .map_or(false, |a| a == "-nolabels");
+                    if hide_labels && base_addr.is_err() {
+                        // if -labels was provided, ensure base_addr is valid
+                        base_addr = Ok(segment.get_lower_bound());
                     }
 
-                    // reached end of dump and/or allocated memory
-                    let index = nth * row_size + offset;
-                    if index >= dump_len {
-                        break;
-                    };
+                    let base_addr = base_addr? as usize;
 
-                    // automatically move upwards when displaying stack
-                    let address = if segment == Segment::Stack {
-                        base_addr - index
-                    } else {
-                        base_addr + index
-                    };
+                    // for most cases this is a no-op, but if given an address in the stack we should
+                    // reverse the order of the scan
+                    segment = get_segment(base_addr as u32);
 
-                    let byte = state
-                        .runtime
-                        .timeline()
-                        .state()
-                        .read_mem_byte_uninit_unchecked(address as u32)
-                        .unwrap();
+                    let default_size = 16;
+                    let row_size: usize = termsize::get()
+                        .map_or(default_size, |size|
+                            // subtract "0x{:8x}: " length and allow for extra length in representation
+                            // TODO: allow rows longer than 16 bytes? can be done by removing .min() but not very readable
+                            (((size.cols - 12 - 1) * 2 / 7) as usize).min(default_size))
+                        .max(1);
 
-                    // TODO: combine these when if-let chaining is stabilised
-                    if !hide_labels {
-                        if let Some((label, addr)) = binary
-                            .labels
-                            .iter()
-                            .find(|(_, &addr)| addr == address as u32)
-                        {
-                            let offset = byte_repr.len();
-                            label_strs.push(arrow_tips.clone());
-                            label_strs.last_mut().unwrap().pad_insert(
-                                offset,
-                                format!(
-                                    "{}: {}{}",
-                                    label.bold().yellow(),
-                                    "0x".yellow(),
-                                    format!("{addr:08x}").purple()
-                                )
+                    let mut rows: usize = dump_len / row_size;
+                    if dump_len % row_size != 0 {
+                        rows += 1;
+                    }
+                    let offset: usize = row_size * 5 / 2;
+
+                    for nth in 0..rows {
+                        let mut label_strs: Vec<WrappedString> = Vec::new();
+                        let mut arrow_tips = WrappedString::new();
+                        let mut byte_repr = String::with_capacity(row_size * 3);
+                        let mut printable_repr = String::with_capacity(row_size);
+
+                        for offset in 0..row_size {
+                            // print in groups of 2 (`xxd` format)
+                            if offset % 2 == 0 {
+                                byte_repr.push(' ');
+                            }
+
+                            // reached end of dump and/or allocated memory
+                            let index = nth * row_size + offset;
+                            if index >= dump_len {
+                                break;
+                            };
+
+                            // automatically move upwards when displaying stack
+                            let address = if segment == Segment::Stack {
+                                base_addr - index
+                            } else {
+                                base_addr + index
+                            };
+
+                            let byte = state
+                                .runtime
+                                .timeline()
+                                .state()
+                                .read_mem_byte_uninit_unchecked(address as u32)
+                                .unwrap();
+
+                            // TODO: combine these when if-let chaining is stabilised
+                            if !hide_labels {
+                                if let Some((label, addr)) = binary
+                                    .labels
+                                        .iter()
+                                        .find(|(_, &addr)| addr == address as u32)
+                                {
+                                    let offset = byte_repr.len();
+                                    label_strs.push(arrow_tips.clone());
+                                    label_strs.last_mut().unwrap().pad_insert(
+                                        offset,
+                                        format!(
+                                            "{}: {}{}",
+                                            label.bold().yellow(),
+                                            "0x".yellow(),
+                                            format!("{addr:08x}").purple()
+                                        )
+                                        .as_ref(),
+                                    );
+                                    arrow_tips.pad_insert(offset, "|");
+                                }
+                            }
+
+                            byte_repr.push_str(render_data(byte).as_ref());
+                            printable_repr.push_str(
+                                byte.as_option()
+                                .map(|&value| value as u32)
+                                .and_then(char::from_u32)
+                                .map(|c| c.escape())
+                                .unwrap_or("_".bright_black().to_string())
                                 .as_ref(),
                             );
-                            arrow_tips.pad_insert(offset, "|");
                         }
+
+                        let marker = if segment == Segment::Stack {
+                            base_addr - nth * row_size
+                        } else {
+                            base_addr + nth * row_size
+                        };
+
+                        if !label_strs.is_empty() {
+                            label_strs
+                                .iter()
+                                .for_each(|l| println!("{} {}", " ".repeat(10), l));
+
+                            println!("{} {}", " ".repeat(10), arrow_tips);
+                        }
+
+                        println!(
+                            "{}{:08x}:{:offset$}  {}",
+                            "0x".yellow(),
+                            marker,
+                            byte_repr,
+                            printable_repr,
+                        );
                     }
 
-                    byte_repr.push_str(render_data(byte).as_ref());
-                    printable_repr.push_str(
-                        byte.as_option()
-                            .map(|&value| value as u32)
-                            .and_then(char::from_u32)
-                            .map(|c| c.escape())
-                            .unwrap_or("_".bright_black().to_string())
-                            .as_ref(),
-                    );
-                }
-
-                let marker = if segment == Segment::Stack {
-                    base_addr - nth * row_size
-                } else {
-                    base_addr + nth * row_size
-                };
-
-                if !label_strs.is_empty() {
-                    label_strs
-                        .iter()
-                        .for_each(|l| println!("{} {}", " ".repeat(10), l));
-
-                    println!("{} {}", " ".repeat(10), arrow_tips);
-                }
-
-                println!(
-                    "{}{:08x}:{:offset$}  {}",
-                    "0x".yellow(),
-                    marker,
-                    byte_repr,
-                    printable_repr,
-                );
-            }
-
-            Ok("".into())
-        },
+                    Ok("".into())
+                },
     )
 }
 

--- a/crates/mipsy_interactive/src/interactive/commands/examine.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/examine.rs
@@ -20,7 +20,7 @@ pub(crate) fn command() -> Command {
         .with_desc("examine memory contents")
         .with_exact_args()
         // TODO: again, get a context to sanitise and hint this
-        .with_optional_arg(Argument::new("section", |_, a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _, _| vec![
+        .with_optional_arg(Argument::new("section", |a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _| vec![
                 "",
                 ".data",
                 ".text",
@@ -28,10 +28,10 @@ pub(crate) fn command() -> Command {
                 ".kdata",
                 ".ktext",
         ].into_iter().map(str::to_owned).collect()))
-        .with_optional_arg(Argument::new("len", |_, a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _, _| vec![]))
+        .with_optional_arg(Argument::new("len", |a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _| vec![]))
         // TODO: maybe lable or register hints depending on
-        .with_optional_arg(Argument::new("addr", |_, a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _, _| vec![]))
-        .with_optional_arg(Argument::new("-nolabels", |_, a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _, _| vec![]))
+        .with_optional_arg(Argument::new("addr", |a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _| vec![]))
+        .with_optional_arg(Argument::new("-nolabels", |a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _| vec![]))
         .with_help(
             format!(
                 "Examine memory contents in a format akin to the tool `xxd`.\n\

--- a/crates/mipsy_interactive/src/interactive/commands/examine.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/examine.rs
@@ -20,12 +20,12 @@ pub(crate) fn command() -> Command {
         .with_desc("examine memory contents")
         .with_exact_args()
         // TODO: again, get a context to sanitise and hint this
-        .with_optional_arg(Argument::new("section", |a| Ok(ArgumentKind::Any(a.to_owned())), |_, _| vec![]))
-        .with_optional_arg(Argument::new("len", |a| Ok(ArgumentKind::Any(a.to_owned())), |_, _| vec![]))
-        .with_optional_arg(Argument::new("addr", |a| Ok(ArgumentKind::Any(a.to_owned())), |_, _| vec![]))
-        .with_optional_arg(Argument::new("-nolabels", |a| Ok(ArgumentKind::Any(a.to_owned())), |_, _| vec![]))
+        .with_optional_arg(Argument::new("section", |a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _| vec![]))
+        .with_optional_arg(Argument::new("len", |a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _| vec![]))
+        .with_optional_arg(Argument::new("addr", |a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _| vec![]))
+        .with_optional_arg(Argument::new("-nolabels", |a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _| vec![]))
         .with_exec(
-        |_, state, label, args| {
+        |_, state, _, label, args| {
             let mut args = &args_text(args)[..];
             // TODO: <enter> to examine the next chunk of memory
             if label == "__help__" {
@@ -89,7 +89,7 @@ pub(crate) fn command() -> Command {
 
             let hide_labels = args
                 .get(0)
-                .map_or(false, |&a| a.as_str() == "-nolabels");
+                .map_or(false, |a| a == "-nolabels");
             if hide_labels && base_addr.is_err() {
                 // if -labels was provided, ensure base_addr is valid
                 base_addr = Ok(segment.get_lower_bound());

--- a/crates/mipsy_interactive/src/interactive/commands/examine.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/examine.rs
@@ -20,10 +20,10 @@ pub(crate) fn command() -> Command {
         .with_desc("examine memory contents")
         .with_exact_args()
         // TODO: again, get a context to sanitise and hint this
-        .with_optional_arg(Argument::new("section", |a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _| vec![]))
-        .with_optional_arg(Argument::new("len", |a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _| vec![]))
-        .with_optional_arg(Argument::new("addr", |a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _| vec![]))
-        .with_optional_arg(Argument::new("-nolabels", |a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _| vec![]))
+        .with_optional_arg(Argument::new("section", |_, a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _, _| vec![]))
+        .with_optional_arg(Argument::new("len", |_, a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _, _| vec![]))
+        .with_optional_arg(Argument::new("addr", |_, a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _, _| vec![]))
+        .with_optional_arg(Argument::new("-nolabels", |_, a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _, _| vec![]))
         .with_help(
             format!(
                 "Examine memory contents in a format akin to the tool `xxd`.\n\

--- a/crates/mipsy_interactive/src/interactive/commands/examine.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/examine.rs
@@ -20,8 +20,16 @@ pub(crate) fn command() -> Command {
         .with_desc("examine memory contents")
         .with_exact_args()
         // TODO: again, get a context to sanitise and hint this
-        .with_optional_arg(Argument::new("section", |_, a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _, _| vec![]))
+        .with_optional_arg(Argument::new("section", |_, a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _, _| vec![
+                "",
+                ".data",
+                ".text",
+                ".stack",
+                ".kdata",
+                ".ktext",
+        ].into_iter().map(str::to_owned).collect()))
         .with_optional_arg(Argument::new("len", |_, a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _, _| vec![]))
+        // TODO: maybe lable or register hints depending on
         .with_optional_arg(Argument::new("addr", |_, a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _, _| vec![]))
         .with_optional_arg(Argument::new("-nolabels", |_, a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _, _| vec![]))
         .with_help(

--- a/crates/mipsy_interactive/src/interactive/commands/examine.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/examine.rs
@@ -47,10 +47,10 @@ pub(crate) fn command() -> Command {
             )
             )
             .with_exec(
-                |_, state, _, args| {
+                |_, helper, args| {
                     let mut args = &args_text(args)[..];
                     // TODO: <enter> to examine the next chunk of memory
-                    let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
+                    let binary = helper.state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
 
                     let mut segment = if let Some(segment) =
                         args.get(0).and_then(|segment| match segment.as_ref() {
@@ -75,7 +75,7 @@ pub(crate) fn command() -> Command {
                         128
                     };
 
-                    let mut base_addr = if let Some(base) = args.get(0).map(|arg| parse_arg(state, arg)) {
+                    let mut base_addr = if let Some(base) = args.get(0).map(|arg| parse_arg(&helper.state, arg)) {
                         if base.is_ok() {
                             args = &args[1..];
                         }
@@ -137,7 +137,7 @@ pub(crate) fn command() -> Command {
                                 base_addr + index
                             };
 
-                            let byte = state
+                            let byte = helper.state
                                 .runtime
                                 .timeline()
                                 .state()

--- a/crates/mipsy_interactive/src/interactive/commands/examine.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/examine.rs
@@ -6,19 +6,26 @@ use mipsy_lib::{
 use mipsy_parser::{MpArgument, MpImmediate, MpNumber};
 use std::{fmt::Display, str::FromStr};
 
-use crate::interactive::error::CommandError;
+use crate::interactive::{commands::watchpoint::args_text, error::CommandError};
 
 use super::*;
 
-pub(crate) fn examine_command() -> Command {
-    command(
-        "examine",
-        vec!["e", "ex", "x", "dump"],
-        vec![],
-        vec!["section", "len", "addr", "-nolabels"],
-        vec![],
-        "examine memory contents",
-        |_, state, label, mut args| {
+pub(crate) fn command() -> Command {
+    Command::new()
+        .with_name("examine")
+        .with_name("e")
+        .with_name("ex")
+        .with_name("x")
+        .with_name("dump")
+        .with_desc("examine memory contents")
+        .with_exact_args()
+        .with_optional_arg(Argument::new("section", |a| Ok(ArgumentKind::Any(a.to_owned()))))
+        .with_optional_arg(Argument::new("len", |a| Ok(ArgumentKind::Any(a.to_owned()))))
+        .with_optional_arg(Argument::new("addr", |a| Ok(ArgumentKind::Any(a.to_owned()))))
+        .with_optional_arg(Argument::new("-nolabels", |a| Ok(ArgumentKind::Any(a.to_owned()))))
+        .with_exec(
+        |_, state, label, args| {
+            let mut args = &args_text(args)[..];
             // TODO: <enter> to examine the next chunk of memory
             if label == "__help__" {
                 return Ok(
@@ -81,7 +88,7 @@ pub(crate) fn examine_command() -> Command {
 
             let hide_labels = args
                 .get(0)
-                .map_or(false, |a| a == &String::from("-nolabels"));
+                .map_or(false, |&a| a.as_str() == "-nolabels");
             if hide_labels && base_addr.is_err() {
                 // if -labels was provided, ensure base_addr is valid
                 base_addr = Ok(segment.get_lower_bound());

--- a/crates/mipsy_interactive/src/interactive/commands/exit.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/exit.rs
@@ -8,7 +8,7 @@ pub(crate) fn command() -> Command {
         .with_name("quit")
         .with_name("q")
         .with_desc("exit mipsy")
-        .with_exec(|_, _, label, _| {
+        .with_exec(|_, _, _, label, _| {
             if label == "__help__" {
                 Ok("Immediately exits mipsy".into())
             } else {

--- a/crates/mipsy_interactive/src/interactive/commands/exit.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/exit.rs
@@ -8,11 +8,6 @@ pub(crate) fn command() -> Command {
         .with_name("quit")
         .with_name("q")
         .with_desc("exit mipsy")
-        .with_exec(|_, _, _, label, _| {
-            if label == "__help__" {
-                Ok("Immediately exits mipsy".into())
-            } else {
-                std::process::exit(0)
-            }
-        })
+        .with_help("Immediately exits mipsy".to_owned())
+        .with_exec(|_, _, _, _| std::process::exit(0))
 }

--- a/crates/mipsy_interactive/src/interactive/commands/exit.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/exit.rs
@@ -9,5 +9,5 @@ pub(crate) fn command() -> Command {
         .with_name("q")
         .with_desc("exit mipsy")
         .with_help("Immediately exits mipsy".to_owned())
-        .with_exec(|_, _, _, _| std::process::exit(0))
+        .with_exec(|_, _, _| std::process::exit(0))
 }

--- a/crates/mipsy_interactive/src/interactive/commands/exit.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/exit.rs
@@ -1,20 +1,18 @@
 use super::*;
 
 #[allow(unreachable_code)]
-pub(crate) fn exit_command() -> Command {
-    command(
-        "exit",
-        vec!["ex", "quit", "q"],
-        vec![],
-        vec![],
-        vec![],
-        "exit mipsy",
-        |_, _state, label, _args| {
+pub(crate) fn command() -> Command {
+    Command::new()
+        .with_name("exit")
+        .with_name("ex")
+        .with_name("quit")
+        .with_name("q")
+        .with_desc("exit mipsy")
+        .with_exec(|_, _, label, _| {
             if label == "__help__" {
-                return Ok("Immediately exits mipsy".into());
+                Ok("Immediately exits mipsy".into())
+            } else {
+                std::process::exit(0)
             }
-
-            std::process::exit(0)
-        },
-    )
+        })
 }

--- a/crates/mipsy_interactive/src/interactive/commands/help.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/help.rs
@@ -3,15 +3,17 @@ use crate::{interactive::error::CommandError, prompt};
 use super::*;
 use colored::*;
 
-pub(crate) fn help_command() -> Command {
-    command(
-        "help",
-        vec!["h", "?"],
-        vec![],
-        vec!["command"],
-        vec![],
-        "print this help text, or specific help for a command",
-        |_, state, label, args| {
+pub(crate) fn command() -> Command {
+    Command::new()
+        .with_name("help")
+        .with_name("h")
+        .with_name("?")
+        .with_desc("print this help text, or specific help for a command")
+        .with_exact_args()
+        .with_optional_arg(Argument::new("command", |a| {
+            Ok(ArgumentKind::Command(a.to_owned()))
+        }))
+        .with_exec(|_, state, label, args| {
             if label == "__help__" {
                 return Ok(format!(
                     "Prints the general help text for all mipsy commands, or more in-depth\n\
@@ -20,7 +22,7 @@ pub(crate) fn help_command() -> Command {
                 ));
             }
 
-            if let Some(command) = args.first() {
+            if let Some(ArgumentKind::Command(command)) = args.first() {
                 let mut command =
                     &state
                         .find_command(command)
@@ -28,31 +30,62 @@ pub(crate) fn help_command() -> Command {
                             command: command.clone(),
                         })?;
 
-                let mut args = &args[1..];
-                let mut parts = vec![command.name.yellow().bold().to_string()];
+                let mut args = &args[1..]
+                    .iter()
+                    .map(|a| match a {
+                        ArgumentKind::Any(a) => a,
+                        _ => unreachable!(),
+                    })
+                    .collect::<Vec<_>>()[..];
+                let mut parts = vec![command
+                    .names
+                    .get(0)
+                    .expect("no command name")
+                    .yellow()
+                    .bold()
+                    .to_string()];
 
                 while !args.is_empty() {
                     let subcmd = command
                         .subcommands
                         .iter()
-                        .find(|c| c.name == args[0] || c.aliases.contains(&args[0]));
+                        .find(|c| c.names.contains(&args[0]));
                     if let Some(subcmd) = subcmd {
                         command = subcmd;
-                        parts.push(subcmd.name.yellow().bold().to_string());
+                        parts.push(
+                            subcmd
+                                .names
+                                .get(0)
+                                .expect("command has no name")
+                                .yellow()
+                                .bold()
+                                .to_string(),
+                        );
                     }
 
                     args = &args[1..];
                 }
 
                 println!("\n{}\n", get_command_formatted(command, parts));
-                println!("{}", command.exec(state, "__help__", args).unwrap());
+                println!(
+                    "{}",
+                    command
+                        .exec(
+                            state,
+                            "__help__",
+                            args.iter()
+                                .map(|&a| a.clone())
+                                .collect::<Vec<_>>()
+                                .as_slice()
+                        )
+                        .unwrap()
+                );
 
-                if !command.aliases.is_empty() {
+                if !command.names[1..].is_empty() {
                     prompt::banner("\naliases".green().bold());
                     println!(
                         "{}",
-                        command
-                            .aliases
+                        command.names[1..]
                             .iter()
                             .map(|s| s.yellow().bold().to_string())
                             .collect::<Vec<String>>()
@@ -66,24 +99,24 @@ pub(crate) fn help_command() -> Command {
             let mut max_len = 0;
 
             for command in state.commands.iter() {
-                let mut len = command.name.len();
+                let mut len = command.names.get(0).expect("no named command").len();
 
                 match &command.args {
                     Arguments::Exactly { required, optional } => {
                         len += required.len();
                         for arg in required.iter() {
-                            len += arg.len() + 2;
+                            len += arg.name.len() + 2;
                         }
 
                         len += optional.len();
                         for arg in optional.iter() {
-                            len += arg.len() + 2;
+                            len += arg.name.len() + 2;
                         }
                     }
                     Arguments::VarArgs { required, format } => {
                         len += required.len();
                         for arg in required.iter() {
-                            len += arg.len() + 2;
+                            len += arg.name.len() + 2;
                         }
 
                         len += 1;
@@ -114,7 +147,13 @@ pub(crate) fn help_command() -> Command {
                         }
                     };
 
-                let parts = vec![command.name.yellow().bold().to_string()];
+                let parts = vec![command
+                    .names
+                    .get(0)
+                    .expect("command has no name")
+                    .yellow()
+                    .bold()
+                    .to_string()];
                 let name_args = get_command_formatted(command, parts);
 
                 let char_len = name_args.len() - extra_color_len;
@@ -136,8 +175,7 @@ pub(crate) fn help_command() -> Command {
             println!();
 
             Ok("".into())
-        },
-    )
+        })
 }
 
 fn get_command_formatted(cmd: &Command, mut parts: Vec<String>) -> String {
@@ -146,14 +184,14 @@ fn get_command_formatted(cmd: &Command, mut parts: Vec<String>) -> String {
             parts.append(
                 &mut required
                     .iter()
-                    .map(|arg| format!("<{}>", arg).magenta().to_string())
+                    .map(|arg| format!("<{}>", arg.name).magenta().to_string())
                     .collect::<Vec<String>>(),
             );
 
             parts.append(
                 &mut optional
                     .iter()
-                    .map(|arg| format!("[{}]", arg).bright_magenta().to_string())
+                    .map(|arg| format!("[{}]", arg.name).bright_magenta().to_string())
                     .collect::<Vec<String>>(),
             );
         }
@@ -161,7 +199,7 @@ fn get_command_formatted(cmd: &Command, mut parts: Vec<String>) -> String {
             parts.append(
                 &mut required
                     .iter()
-                    .map(|arg| format!("<{}>", arg).magenta().to_string())
+                    .map(|arg| format!("<{}>", arg.name).magenta().to_string())
                     .collect::<Vec<String>>(),
             );
 

--- a/crates/mipsy_interactive/src/interactive/commands/help.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/help.rs
@@ -82,18 +82,18 @@ pub(crate) fn command() -> Command {
                     Arguments::Exactly { required, optional } => {
                         len += required.len();
                         for arg in required.iter() {
-                            len += arg.name.len() + 2;
+                            len += arg.name().len() + 2;
                         }
 
                         len += optional.len();
                         for arg in optional.iter() {
-                            len += arg.name.len() + 2;
+                            len += arg.name().len() + 2;
                         }
                     }
                     Arguments::VarArgs { required, variadic } => {
                         len += required.len();
                         for arg in required.iter() {
-                            len += arg.name.len() + 2;
+                            len += arg.name().len() + 2;
                         }
 
                         len += 1;
@@ -153,14 +153,14 @@ fn get_command_formatted(cmd: &Command, mut parts: Vec<String>) -> String {
             parts.append(
                 &mut required
                     .iter()
-                    .map(|arg| format!("<{}>", arg.name).magenta().to_string())
+                    .map(|arg| format!("<{}>", arg.name()).magenta().to_string())
                     .collect::<Vec<String>>(),
             );
 
             parts.append(
                 &mut optional
                     .iter()
-                    .map(|arg| format!("[{}]", arg.name).bright_magenta().to_string())
+                    .map(|arg| format!("[{}]", arg.name()).bright_magenta().to_string())
                     .collect::<Vec<String>>(),
             );
         }
@@ -168,7 +168,7 @@ fn get_command_formatted(cmd: &Command, mut parts: Vec<String>) -> String {
             parts.append(
                 &mut required
                     .iter()
-                    .map(|arg| format!("<{}>", arg.name).magenta().to_string())
+                    .map(|arg| format!("<{}>", arg.name()).magenta().to_string())
                     .collect::<Vec<String>>(),
             );
 

--- a/crates/mipsy_interactive/src/interactive/commands/help.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/help.rs
@@ -1,4 +1,4 @@
-use crate::interactive::{error::CommandError, prompt};
+use crate::{interactive::error::CommandError, prompt};
 
 use super::*;
 use colored::*;

--- a/crates/mipsy_interactive/src/interactive/commands/help.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/help.rs
@@ -25,16 +25,13 @@ pub(crate) fn command() -> Command {
                     .collect()
             },
         ))
-        .with_exec(|_, state, helper, label, args| {
+        .with_help(format!(
+            "Prints the general help text for all mipsy commands, or more in-depth\n\
+                \x20 help for a specific {} if specified, including available aliases.",
+            "[command]".magenta()
+        ))
+        .with_exec(|_, state, _, args| {
             let args = &args_text(args);
-            if label == "__help__" {
-                return Ok(format!(
-                    "Prints the general help text for all mipsy commands, or more in-depth\n\
-                     \x20 help for a specific {} if specified, including available aliases.",
-                    "[command]".magenta()
-                ));
-            }
-
             if let Some(command) = args.first() {
                 let mut command =
                     &state
@@ -74,8 +71,7 @@ pub(crate) fn command() -> Command {
                 }
 
                 println!("\n{}\n", get_command_formatted(command, parts));
-                // TODO: better help than "__help__"
-                println!("{}", command.exec(state, helper, "__help__", args).unwrap());
+                println!("{}", command.help);
 
                 if !command.names[1..].is_empty() {
                     prompt::banner("\naliases".green().bold());

--- a/crates/mipsy_interactive/src/interactive/commands/help.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/help.rs
@@ -30,15 +30,14 @@ pub(crate) fn command() -> Command {
                 \x20 help for a specific {} if specified, including available aliases.",
             "[command]".magenta()
         ))
-        .with_exec(|_, state, _, args| {
+        .with_exec(|_, helper, args| {
             let args = &args_text(args);
             if let Some(command) = args.first() {
-                let mut command =
-                    &state
-                        .find_command(&command)
-                        .ok_or(CommandError::HelpUnknownCommand {
-                            command: command.to_owned(),
-                        })?;
+                let mut command = &helper.state.find_command(&command).ok_or(
+                    CommandError::HelpUnknownCommand {
+                        command: command.to_owned(),
+                    },
+                )?;
 
                 let mut args = &args[1..];
                 let mut parts = vec![command
@@ -90,7 +89,7 @@ pub(crate) fn command() -> Command {
 
             let mut max_len = 0;
 
-            for command in state.commands.iter() {
+            for command in helper.state.commands.iter() {
                 let mut len = command.names.get(0).expect("no named command").len();
 
                 match &command.args {
@@ -123,7 +122,7 @@ pub(crate) fn command() -> Command {
             }
 
             println!("{}", "\nCOMMANDS:".green().bold());
-            for command in state.commands.iter() {
+            for command in helper.state.commands.iter() {
                 let extra_color_len = "".yellow().bold().to_string().len()
                     + match &command.args {
                         Arguments::Exactly { required, optional } => {

--- a/crates/mipsy_interactive/src/interactive/commands/help.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/help.rs
@@ -16,8 +16,8 @@ pub(crate) fn command() -> Command {
         // TODO: context for sanitisation
         .with_optional_arg(Argument::new(
             "command",
-            |a, _| Ok(ArgumentKind::String(a.to_owned())),
-            |_, h| {
+            |_, a, _| Ok(ArgumentKind::String(a.to_owned())),
+            |_, _, h| {
                 h.state
                     .commands
                     .iter()

--- a/crates/mipsy_interactive/src/interactive/commands/help.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/help.rs
@@ -1,4 +1,7 @@
-use crate::{interactive::error::CommandError, prompt};
+use crate::{
+    interactive::{commands::watchpoint::args_text, error::CommandError},
+    prompt,
+};
 
 use super::*;
 use colored::*;
@@ -13,10 +16,17 @@ pub(crate) fn command() -> Command {
         // TODO: context for sanitisation
         .with_optional_arg(Argument::new(
             "command",
-            |a| Ok(ArgumentKind::Command(a.to_owned())),
-            |_, h| h.commands.iter().map(|c| c.name().to_owned()).collect(),
+            |a, _| Ok(ArgumentKind::String(a.to_owned())),
+            |_, h| {
+                h.state
+                    .commands
+                    .iter()
+                    .map(|c| c.name().to_owned())
+                    .collect()
+            },
         ))
-        .with_exec(|_, state, label, args| {
+        .with_exec(|_, state, helper, label, args| {
+            let args = &args_text(args);
             if label == "__help__" {
                 return Ok(format!(
                     "Prints the general help text for all mipsy commands, or more in-depth\n\
@@ -25,21 +35,15 @@ pub(crate) fn command() -> Command {
                 ));
             }
 
-            if let Some(ArgumentKind::Command(command)) = args.first() {
+            if let Some(command) = args.first() {
                 let mut command =
                     &state
-                        .find_command(command)
+                        .find_command(&command)
                         .ok_or(CommandError::HelpUnknownCommand {
-                            command: command.clone(),
+                            command: command.to_owned(),
                         })?;
 
-                let mut args = &args[1..]
-                    .iter()
-                    .map(|a| match a {
-                        ArgumentKind::Any(a) => a,
-                        _ => unreachable!(),
-                    })
-                    .collect::<Vec<_>>()[..];
+                let mut args = &args[1..];
                 let mut parts = vec![command
                     .names
                     .get(0)
@@ -70,19 +74,8 @@ pub(crate) fn command() -> Command {
                 }
 
                 println!("\n{}\n", get_command_formatted(command, parts));
-                println!(
-                    "{}",
-                    command
-                        .exec(
-                            state,
-                            "__help__",
-                            args.iter()
-                                .map(|&a| a.clone())
-                                .collect::<Vec<_>>()
-                                .as_slice()
-                        )
-                        .unwrap()
-                );
+                // TODO: better help than "__help__"
+                println!("{}", command.exec(state, helper, "__help__", args).unwrap());
 
                 if !command.names[1..].is_empty() {
                     prompt::banner("\naliases".green().bold());

--- a/crates/mipsy_interactive/src/interactive/commands/help.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/help.rs
@@ -24,7 +24,7 @@ pub(crate) fn command() -> Command {
         //             .collect()
         //     },
         // ))
-        .with_var_args(Argument::from_name("command"))
+        .with_var_args(Argument::from_name("[command]".magenta().to_string()))
         .with_help(format!(
             "Prints the general help text for all mipsy commands, or more in-depth\n\
                 \x20 help for a specific {} if specified, including available aliases.",
@@ -40,11 +40,7 @@ pub(crate) fn command() -> Command {
                 )?;
 
                 let mut args = &args[1..];
-                let mut parts = vec![command
-                    .name()
-                    .yellow()
-                    .bold()
-                    .to_string()];
+                let mut parts = vec![command.name().yellow().bold().to_string()];
 
                 while !args.is_empty() {
                     let subcmd = command
@@ -53,13 +49,7 @@ pub(crate) fn command() -> Command {
                         .find(|c| c.names.contains(&args[0]));
                     if let Some(subcmd) = subcmd {
                         command = subcmd;
-                        parts.push(
-                            subcmd
-                                .name()
-                                .yellow()
-                                .bold()
-                                .to_string(),
-                        );
+                        parts.push(subcmd.name().yellow().bold().to_string());
                     }
 
                     args = &args[1..];
@@ -125,22 +115,16 @@ pub(crate) fn command() -> Command {
                             "".magenta().to_string().len() * required.len()
                                 + "".bright_magenta().to_string().len() * optional.len()
                         }
-                        Arguments::VarArgs {
-                            required,
-                            ..
-                        } => {
+                        Arguments::VarArgs { required, .. } => {
                             "".magenta().to_string().len() * required.len()
                                 + "".bright_magenta().to_string().len()
                         }
                     };
 
-                let parts = vec![command
-                    .name()
-                    .yellow()
-                    .bold()
-                    .to_string()];
+                let parts = vec![command.name().yellow().bold().to_string()];
                 let name_args = get_command_formatted(command, parts);
 
+                // TODO: doesnt work with non coloured text :/
                 let char_len = name_args.len().saturating_sub(extra_color_len);
                 let extra_padding = max_len - char_len;
 

--- a/crates/mipsy_interactive/src/interactive/commands/help.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/help.rs
@@ -12,19 +12,19 @@ pub(crate) fn command() -> Command {
         .with_name("h")
         .with_name("?")
         .with_desc("print this help text, or specific help for a command")
-        .with_exact_args()
-        // TODO: context for sanitisation
-        .with_optional_arg(Argument::new(
-            "command",
-            |_, a, _| Ok(ArgumentKind::String(a.to_owned())),
-            |_, _, h| {
-                h.state
-                    .commands
-                    .iter()
-                    .map(|c| c.name().to_owned())
-                    .collect()
-            },
-        ))
+        // .with_exact_args()
+        // .with_optional_arg(Argument::new(
+        //     "command",
+        //     |_, a, _| Ok(ArgumentKind::String(a.to_owned())),
+        //     |_, _, h| {
+        //         h.state
+        //             .commands
+        //             .iter()
+        //             .map(|c| c.name().to_owned())
+        //             .collect()
+        //     },
+        // ))
+        .with_var_args(Argument::from_name("command"))
         .with_help(format!(
             "Prints the general help text for all mipsy commands, or more in-depth\n\
                 \x20 help for a specific {} if specified, including available aliases.",
@@ -41,9 +41,7 @@ pub(crate) fn command() -> Command {
 
                 let mut args = &args[1..];
                 let mut parts = vec![command
-                    .names
-                    .get(0)
-                    .expect("no command name")
+                    .name()
                     .yellow()
                     .bold()
                     .to_string()];
@@ -57,9 +55,7 @@ pub(crate) fn command() -> Command {
                         command = subcmd;
                         parts.push(
                             subcmd
-                                .names
-                                .get(0)
-                                .expect("command has no name")
+                                .name()
                                 .yellow()
                                 .bold()
                                 .to_string(),
@@ -90,7 +86,7 @@ pub(crate) fn command() -> Command {
             let mut max_len = 0;
 
             for command in helper.state.commands.iter() {
-                let mut len = command.names.get(0).expect("no named command").len();
+                let mut len = command.name().len();
 
                 match &command.args {
                     Arguments::Exactly { required, optional } => {
@@ -104,7 +100,7 @@ pub(crate) fn command() -> Command {
                             len += arg.name.len() + 2;
                         }
                     }
-                    Arguments::VarArgs { required, format } => {
+                    Arguments::VarArgs { required, variadic } => {
                         len += required.len();
                         for arg in required.iter() {
                             len += arg.name.len() + 2;
@@ -112,7 +108,7 @@ pub(crate) fn command() -> Command {
 
                         len += 1;
 
-                        len += format.len();
+                        len += variadic.name().len();
                     }
                 }
 
@@ -131,7 +127,7 @@ pub(crate) fn command() -> Command {
                         }
                         Arguments::VarArgs {
                             required,
-                            format: _,
+                            ..
                         } => {
                             "".magenta().to_string().len() * required.len()
                                 + "".bright_magenta().to_string().len()
@@ -139,15 +135,13 @@ pub(crate) fn command() -> Command {
                     };
 
                 let parts = vec![command
-                    .names
-                    .get(0)
-                    .expect("command has no name")
+                    .name()
                     .yellow()
                     .bold()
                     .to_string()];
                 let name_args = get_command_formatted(command, parts);
 
-                let char_len = name_args.len() - extra_color_len;
+                let char_len = name_args.len().saturating_sub(extra_color_len);
                 let extra_padding = max_len - char_len;
 
                 println!(
@@ -186,7 +180,7 @@ fn get_command_formatted(cmd: &Command, mut parts: Vec<String>) -> String {
                     .collect::<Vec<String>>(),
             );
         }
-        Arguments::VarArgs { required, format } => {
+        Arguments::VarArgs { required, variadic } => {
             parts.append(
                 &mut required
                     .iter()
@@ -194,7 +188,7 @@ fn get_command_formatted(cmd: &Command, mut parts: Vec<String>) -> String {
                     .collect::<Vec<String>>(),
             );
 
-            parts.push(format.to_string());
+            parts.push(variadic.name().to_string());
         }
     }
 

--- a/crates/mipsy_interactive/src/interactive/commands/help.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/help.rs
@@ -10,9 +10,12 @@ pub(crate) fn command() -> Command {
         .with_name("?")
         .with_desc("print this help text, or specific help for a command")
         .with_exact_args()
-        .with_optional_arg(Argument::new("command", |a| {
-            Ok(ArgumentKind::Command(a.to_owned()))
-        }))
+        // TODO: context for sanitisation
+        .with_optional_arg(Argument::new(
+            "command",
+            |a| Ok(ArgumentKind::Command(a.to_owned())),
+            |_, h| h.commands.iter().map(|c| c.name().to_owned()).collect(),
+        ))
         .with_exec(|_, state, label, args| {
             if label == "__help__" {
                 return Ok(format!(

--- a/crates/mipsy_interactive/src/interactive/commands/label.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/label.rs
@@ -16,15 +16,12 @@ pub(crate) fn command() -> Command {
             |_, _| vec![],
         ))
         .with_desc("print the address of a label")
-        .with_exec(|_, state, _, label, args| {
-            if label == "__help__" {
-                return Ok(format!(
-                    "Prints the address of the specified {0}.\n\
-                         May error if the specified {0} doesn't exist.",
-                    "<label>".magenta()
-                ));
-            }
-
+        .with_help(format!(
+            "Prints the address of the specified {0}.\n\
+                May error if the specified {0} doesn't exist.",
+            "<label>".magenta()
+        ))
+        .with_exec(|_, state, _, args| {
             let label = String::from(args[0].to_owned());
             let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
 

--- a/crates/mipsy_interactive/src/interactive/commands/label.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/label.rs
@@ -11,7 +11,7 @@ pub(crate) fn command() -> Command {
         .with_exact_args()
         .with_required_arg(Argument::new(
             "label",
-            |_, a, h| {
+            |a, h| {
                 h.state
                     .binary
                     .as_ref()
@@ -25,7 +25,7 @@ pub(crate) fn command() -> Command {
                     // it gets printed later
                     .and_then(|_| Ok(ArgumentKind::String(a.to_owned())))
             },
-            |_, _, h| {
+            |_, h| {
                 h.state
                     .binary
                     .as_ref()
@@ -48,7 +48,7 @@ pub(crate) fn command() -> Command {
             "<label>".magenta()
         ))
         .with_exec(|_, helper, args| {
-            let label = String::from(args[0].to_owned());
+            let label = String::try_from(args[0].to_owned()).unwrap();
             let binary = helper
                 .state
                 .binary

--- a/crates/mipsy_interactive/src/interactive/commands/label.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/label.rs
@@ -12,8 +12,8 @@ pub(crate) fn command() -> Command {
         // TODO: somehow get some context to sanitise & hint this
         .with_required_arg(Argument::new(
             "label",
-            |a, _| Ok(ArgumentKind::String(a.to_owned())),
-            |_, _| vec![],
+            |_, a, _| Ok(ArgumentKind::String(a.to_owned())),
+            |_, _, _| vec![],
         ))
         .with_desc("print the address of a label")
         .with_help(format!(

--- a/crates/mipsy_interactive/src/interactive/commands/label.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/label.rs
@@ -3,15 +3,18 @@ use crate::interactive::{error::CommandError, prompt};
 use super::*;
 use colored::*;
 
-pub(crate) fn label_command() -> Command {
-    command(
-        "label",
-        vec!["la", "lbl"],
-        vec!["label"],
-        vec![],
-        vec![],
-        "print the address of a label",
-        |_, state, label, args| {
+pub(crate) fn command() -> Command {
+    Command::new()
+        .with_name("label")
+        .with_name("la")
+        .with_name("lbl")
+        .with_exact_args()
+        // TODO: somehow get some context to sanitise this
+        .with_required_arg(Argument::new("label", |a| {
+            Ok(ArgumentKind::Label(a.to_owned()))
+        }))
+        .with_desc("print the address of a label")
+        .with_exec(|_, state, label, args| {
             if label == "__help__" {
                 return Ok(format!(
                     "Prints the address of the specified {0}.\n\
@@ -20,7 +23,9 @@ pub(crate) fn label_command() -> Command {
                 ));
             }
 
-            let label = &args[0];
+            let ArgumentKind::Label(label) = &args[0] else {
+                unreachable!()
+            };
             let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
 
             match binary.get_label(label) {
@@ -31,6 +36,5 @@ pub(crate) fn label_command() -> Command {
             }
 
             Ok("".into())
-        },
-    )
+        })
 }

--- a/crates/mipsy_interactive/src/interactive/commands/label.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/label.rs
@@ -9,10 +9,12 @@ pub(crate) fn command() -> Command {
         .with_name("la")
         .with_name("lbl")
         .with_exact_args()
-        // TODO: somehow get some context to sanitise this
-        .with_required_arg(Argument::new("label", |a| {
-            Ok(ArgumentKind::Label(a.to_owned()))
-        }))
+        // TODO: somehow get some context to sanitise & hint this
+        .with_required_arg(Argument::new(
+            "label",
+            |a| Ok(ArgumentKind::Label(a.to_owned())),
+            |_, _| vec![],
+        ))
         .with_desc("print the address of a label")
         .with_exec(|_, state, label, args| {
             if label == "__help__" {

--- a/crates/mipsy_interactive/src/interactive/commands/label.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/label.rs
@@ -12,11 +12,11 @@ pub(crate) fn command() -> Command {
         // TODO: somehow get some context to sanitise & hint this
         .with_required_arg(Argument::new(
             "label",
-            |a| Ok(ArgumentKind::Label(a.to_owned())),
+            |a, _| Ok(ArgumentKind::String(a.to_owned())),
             |_, _| vec![],
         ))
         .with_desc("print the address of a label")
-        .with_exec(|_, state, label, args| {
+        .with_exec(|_, state, _, label, args| {
             if label == "__help__" {
                 return Ok(format!(
                     "Prints the address of the specified {0}.\n\
@@ -25,12 +25,10 @@ pub(crate) fn command() -> Command {
                 ));
             }
 
-            let ArgumentKind::Label(label) = &args[0] else {
-                unreachable!()
-            };
+            let label = String::from(args[0].to_owned());
             let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
 
-            match binary.get_label(label) {
+            match binary.get_label(&label) {
                 Ok(addr) => {
                     prompt::success_nl(format!("{} => 0x{:08x}", label.yellow().bold(), addr))
                 }

--- a/crates/mipsy_interactive/src/interactive/commands/label.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/label.rs
@@ -9,11 +9,37 @@ pub(crate) fn command() -> Command {
         .with_name("la")
         .with_name("lbl")
         .with_exact_args()
-        // TODO: somehow get some context to sanitise & hint this
         .with_required_arg(Argument::new(
             "label",
-            |_, a, _| Ok(ArgumentKind::String(a.to_owned())),
-            |_, _, _| vec![],
+            |_, a, h| {
+                h.state
+                    .binary
+                    .as_ref()
+                    .ok_or(CommandError::MustLoadFile)?
+                    .get_label(a)
+                    .map_err(|_| CommandError::BadArgument {
+                        arg: "<label>".magenta().to_string(),
+                        instead: a.to_owned(),
+                    })
+                    // have to keep it as a string here because
+                    // it gets printed later
+                    .and_then(|_| Ok(ArgumentKind::String(a.to_owned())))
+            },
+            |_, _, h| {
+                h.state
+                    .binary
+                    .as_ref()
+                    .and_then(|b| {
+                        Some(
+                            b.labels
+                                .keys()
+                                .filter(|k| !(k.starts_with("kernel__") || k.starts_with("_start")))
+                                .cloned()
+                                .collect(),
+                        )
+                    })
+                    .unwrap_or_default()
+            },
         ))
         .with_desc("print the address of a label")
         .with_help(format!(
@@ -21,9 +47,13 @@ pub(crate) fn command() -> Command {
                 May error if the specified {0} doesn't exist.",
             "<label>".magenta()
         ))
-        .with_exec(|_, state, _, args| {
+        .with_exec(|_, helper, args| {
             let label = String::from(args[0].to_owned());
-            let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
+            let binary = helper
+                .state
+                .binary
+                .as_ref()
+                .ok_or(CommandError::MustLoadFile)?;
 
             match binary.get_label(&label) {
                 Ok(addr) => {

--- a/crates/mipsy_interactive/src/interactive/commands/labels.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/labels.rs
@@ -12,8 +12,12 @@ pub(crate) fn command() -> Command {
         .with_name("lbls")
         .with_desc("prints the addresses of all labels")
         .with_help("Prints the addresses of all labels in the currently loaded program.".to_owned())
-        .with_exec(|_, state, _, _| {
-            let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
+        .with_exec(|_, helper, _| {
+            let binary = helper
+                .state
+                .binary
+                .as_ref()
+                .ok_or(CommandError::MustLoadFile)?;
 
             let max_len = binary
                 .labels

--- a/crates/mipsy_interactive/src/interactive/commands/labels.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/labels.rs
@@ -11,13 +11,8 @@ pub(crate) fn command() -> Command {
         .with_name("las")
         .with_name("lbls")
         .with_desc("prints the addresses of all labels")
-        .with_exec(|_, state, _, label, _| {
-            if label == "__help__" {
-                return Ok(
-                    "Prints the addresses of all labels in the currently loaded program.".into(),
-                );
-            }
-
+        .with_help("Prints the addresses of all labels in the currently loaded program.".to_owned())
+        .with_exec(|_, state, _, _| {
             let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
 
             let max_len = binary

--- a/crates/mipsy_interactive/src/interactive/commands/labels.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/labels.rs
@@ -4,15 +4,14 @@ use mipsy_lib::DATA_BOT;
 use super::*;
 use colored::*;
 
-pub(crate) fn labels_command() -> Command {
-    command(
-        "labels",
-        vec!["ls", "las", "lbls"],
-        vec![],
-        vec![],
-        vec![],
-        "prints the addresses of all labels",
-        |_, state, label, _args| {
+pub(crate) fn command() -> Command {
+    Command::new()
+        .with_name("labels")
+        .with_name("ls")
+        .with_name("las")
+        .with_name("lbls")
+        .with_desc("prints the addresses of all labels")
+        .with_exec(|_, state, label, _| {
             if label == "__help__" {
                 return Ok(
                     "Prints the addresses of all labels in the currently loaded program.".into(),
@@ -59,6 +58,5 @@ pub(crate) fn labels_command() -> Command {
             println!();
 
             Ok("".into())
-        },
-    )
+        })
 }

--- a/crates/mipsy_interactive/src/interactive/commands/labels.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/labels.rs
@@ -11,7 +11,7 @@ pub(crate) fn command() -> Command {
         .with_name("las")
         .with_name("lbls")
         .with_desc("prints the addresses of all labels")
-        .with_exec(|_, state, label, _| {
+        .with_exec(|_, state, _, label, _| {
             if label == "__help__" {
                 return Ok(
                     "Prints the addresses of all labels in the currently loaded program.".into(),

--- a/crates/mipsy_interactive/src/interactive/commands/load.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/load.rs
@@ -10,22 +10,16 @@ pub(crate) fn command() -> Command {
     Command::new()
         .with_name("load")
         .with_name("l")
-        .with_var_args()
+        .with_var_args(Argument::new(
+            "<files>".magenta().to_string(),
+            |_, a, _| Ok(ArgumentKind::String(a.to_owned())),
+            |_, a, h| h.file_hints(a),
+        ) )
         .with_required_arg(Argument::new(
             "files",
-            |_, a, h| {
-                if h.file_hints(&HintArgs::default()).contains(&a.to_owned()) {
-                    Ok(ArgumentKind::String(a.into()))
-                } else {
-                    Err(CommandError::BadArgument {
-                        arg: "file".to_owned(),
-                        instead: a.to_owned(),
-                    })
-                }
-            },
+            |_, a, _| Ok(ArgumentKind::String(a.to_owned())),
             |_, a, h| h.file_hints(a),
         ))
-        .with_varargs_format("-- {args}".magenta().to_string())
         .with_desc("load a MIPS file to run")
         .with_help(format!(
             "Loads a MIPS file to run, overwriting whatever is currently loaded.\n\

--- a/crates/mipsy_interactive/src/interactive/commands/load.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/load.rs
@@ -34,7 +34,7 @@ pub(crate) fn command() -> Command {
             "step".bold(),
             "print".bold(),
         ))
-        .with_exec(|_, state, _, args| {
+        .with_exec(|_, helper, args| {
             let args = &args_text(args)[..];
 
             let (files, arguments) = {
@@ -71,8 +71,8 @@ pub(crate) fn command() -> Command {
                 program
             };
 
-            state.program = Some(program);
-            let program = state.program.as_ref().unwrap();
+            helper.state.program = Some(program);
+            let program = helper.state.program.as_ref().unwrap();
 
             let binary_files = program
                 .iter()
@@ -80,10 +80,10 @@ pub(crate) fn command() -> Command {
                 .collect();
 
             let binary = mipsy_lib::compile(
-                &state.iset,
+                &helper.state.iset,
                 binary_files,
                 &CompilerOptions::default(),
-                &state.config,
+                &helper.state.config,
             )
             .map_err(|err| CommandError::CannotCompile { mipsy_error: err })?;
 
@@ -96,9 +96,9 @@ pub(crate) fn command() -> Command {
                     .as_slice(),
             );
 
-            state.binary = Some(binary);
-            state.runtime = runtime;
-            state.exited = false;
+            helper.state.binary = Some(binary);
+            helper.state.runtime = runtime;
+            helper.state.exited = false;
 
             let loaded = if program.len() == 1 {
                 "file loaded"

--- a/crates/mipsy_interactive/src/interactive/commands/load.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/load.rs
@@ -1,4 +1,4 @@
-use crate::interactive::{error::CommandError, prompt};
+use crate::interactive::{commands::watchpoint::args_text, error::CommandError, prompt};
 
 use super::*;
 use colored::*;
@@ -15,7 +15,16 @@ pub(crate) fn command() -> Command {
             // TODO: better fs filter
             Argument::new(
                 "files",
-                |a| Ok(ArgumentKind::File(a.into())),
+                |a, h| {
+                    if h.file_hints(&HintArgs::default()).contains(&a.to_owned()) {
+                        Ok(ArgumentKind::String(a.into()))
+                    } else {
+                        Err(CommandError::BadArgument {
+                            arg: "file".to_owned(),
+                            instead: a.to_owned()
+                        })
+                    }
+                },
                 |a, h| h.file_hints(a)
             )
         )
@@ -24,7 +33,7 @@ pub(crate) fn command() -> Command {
         )
         .with_desc("load a MIPS file to run")
         .with_exec(
-            |_, state, label, args| {
+            |_, state, _, label, args| {
                 if label == "__help__" {
                     return Ok(
                         format!(
@@ -37,14 +46,10 @@ pub(crate) fn command() -> Command {
                     );
                 }
 
-                let args = args.iter().map(|a| match a {
-                    ArgumentKind::File(f) => f,
-                    _ => unreachable!()
-                }).map(String::as_str).collect::<Vec<&str>>();
-                let args = args.as_slice();
+                let args = &args_text(args)[..];
 
                 let (files, arguments) = {
-                    if let Some(index) = args.iter().position(|&arg| arg == "--") {
+                    if let Some(index) = args.iter().position(|arg| arg == "--") {
                         let (files, arguments) = args.split_at(index);
 
                         (files, &arguments[1..])
@@ -60,8 +65,7 @@ pub(crate) fn command() -> Command {
                     let mut program = Vec::with_capacity(files.len());
                 for file in files
                     .iter()
-                    .map(|&name| {
-                        let mut name = name;
+                    .map(|mut name| {
                         #[cfg(unix)]
                         if name == "-" {
                             name = &stdin;
@@ -96,7 +100,7 @@ pub(crate) fn command() -> Command {
                 )
                     .map_err(|err| CommandError::CannotCompile { mipsy_error: err })?;
 
-                let runtime = mipsy_lib::runtime(&binary, arguments);
+                let runtime = mipsy_lib::runtime(&binary, arguments.iter().map(String::as_str).collect::<Vec<_>>().as_slice());
 
                 state.binary = Some(binary);
                 state.runtime = runtime;

--- a/crates/mipsy_interactive/src/interactive/commands/load.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/load.rs
@@ -13,7 +13,11 @@ pub(crate) fn command() -> Command {
         .with_var_args()
         .with_required_arg(
             // TODO: better fs filter
-            Argument::new("files", |a| Ok(ArgumentKind::File(a.into())))
+            Argument::new(
+                "files",
+                |a| Ok(ArgumentKind::File(a.into())),
+                |a, h| h.file_hints(a)
+            )
         )
         .with_varargs_format(
             "-- {args}".magenta().to_string()

--- a/crates/mipsy_interactive/src/interactive/commands/load.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/load.rs
@@ -11,23 +11,20 @@ pub(crate) fn command() -> Command {
         .with_name("load")
         .with_name("l")
         .with_var_args()
-        .with_required_arg(
-            // TODO: better fs filter
-            Argument::new(
-                "files",
-                |a, h| {
-                    if h.file_hints(&HintArgs::default()).contains(&a.to_owned()) {
-                        Ok(ArgumentKind::String(a.into()))
-                    } else {
-                        Err(CommandError::BadArgument {
-                            arg: "file".to_owned(),
-                            instead: a.to_owned(),
-                        })
-                    }
-                },
-                |a, h| h.file_hints(a),
-            ),
-        )
+        .with_required_arg(Argument::new(
+            "files",
+            |_, a, h| {
+                if h.file_hints(&HintArgs::default()).contains(&a.to_owned()) {
+                    Ok(ArgumentKind::String(a.into()))
+                } else {
+                    Err(CommandError::BadArgument {
+                        arg: "file".to_owned(),
+                        instead: a.to_owned(),
+                    })
+                }
+            },
+            |_, a, h| h.file_hints(a),
+        ))
         .with_varargs_format("-- {args}".magenta().to_string())
         .with_desc("load a MIPS file to run")
         .with_help(format!(

--- a/crates/mipsy_interactive/src/interactive/commands/load.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/load.rs
@@ -14,7 +14,7 @@ pub(crate) fn command() -> Command {
             "<files>".magenta().to_string(),
             |_, a, _| Ok(ArgumentKind::String(a.to_owned())),
             |_, a, h| h.file_hints(a),
-        ) )
+        ))
         .with_required_arg(Argument::new(
             "files",
             |_, a, _| Ok(ArgumentKind::String(a.to_owned())),

--- a/crates/mipsy_interactive/src/interactive/commands/load.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/load.rs
@@ -12,13 +12,13 @@ pub(crate) fn command() -> Command {
         .with_name("l")
         .with_var_args(Argument::new(
             "<files>".magenta().to_string(),
-            |_, a, _| Ok(ArgumentKind::String(a.to_owned())),
-            |_, a, h| h.file_hints(a),
+            |a, _| Ok(ArgumentKind::String(a.to_owned())),
+            |a, h| h.file_hints(a),
         ))
         .with_required_arg(Argument::new(
             "files",
-            |_, a, _| Ok(ArgumentKind::String(a.to_owned())),
-            |_, a, h| h.file_hints(a),
+            |a, _| Ok(ArgumentKind::String(a.to_owned())),
+            |a, h| h.file_hints(a),
         ))
         .with_desc("load a MIPS file to run")
         .with_help(format!(

--- a/crates/mipsy_interactive/src/interactive/commands/load.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/load.rs
@@ -6,92 +6,107 @@ use mipsy_lib::compile::CompilerOptions;
 use mipsy_parser::TaggedFile;
 use mipsy_utils::expand_tilde;
 
-pub(crate) fn load_command() -> Command {
-    command_varargs(
-        "load",
-        vec!["l"],
-        vec!["files"],
-        "-- {args}".magenta().to_string(),
-        vec![],
-        "load a MIPS file to run",
-        |_, state, label, args| {
-            if label == "__help__" {
-                return Ok(
-                    format!(
-                        "Loads a MIPS file to run, overwriting whatever is currently loaded.\n\
-                         This command must be run prior to many others, such as `{}`, `{}`, `{}`, ...",
-                        "run".bold(),
-                        "step".bold(),
-                        "print".bold(),
-                    ),
-                );
-            }
-
-            let (files, arguments) = {
-                if let Some(index) = args.iter().position(|arg| arg == "--") {
-                    let (files, arguments) = args.split_at(index);
-
-                    (files, &arguments[1..])
-                } else {
-                    (args, &[][..])
+pub(crate) fn command() -> Command {
+    Command::new()
+        .with_name("load")
+        .with_name("l")
+        .with_var_args()
+        .with_required_arg(
+            // TODO: better fs filter
+            Argument::new("files", |a| Ok(ArgumentKind::File(a.into())))
+        )
+        .with_varargs_format(
+            "-- {args}".magenta().to_string()
+        )
+        .with_desc("load a MIPS file to run")
+        .with_exec(
+            |_, state, label, args| {
+                if label == "__help__" {
+                    return Ok(
+                        format!(
+                            "Loads a MIPS file to run, overwriting whatever is currently loaded.\n\
+                            This command must be run prior to many others, such as `{}`, `{}`, `{}`, ...",
+                            "run".bold(),
+                            "step".bold(),
+                            "print".bold(),
+                        ),
+                    );
                 }
-            };
 
-            #[cfg(unix)]
-            let stdin = String::from("/dev/stdin");
+                let args = args.iter().map(|a| match a {
+                    ArgumentKind::File(f) => f,
+                    _ => unreachable!()
+                }).map(String::as_str).collect::<Vec<&str>>();
+                let args = args.as_slice();
 
-            let program: Vec<_> = files
-                .iter()
-                .map(|name| {
-                    let mut path = name;
+                let (files, arguments) = {
+                    if let Some(index) = args.iter().position(|&arg| arg == "--") {
+                        let (files, arguments) = args.split_at(index);
 
-                    #[cfg(unix)]
-                    if path == "-" {
-                        path = &stdin;
+                        (files, &arguments[1..])
+                    } else {
+                        (args, &[][..])
                     }
+                };
 
-                    match std::fs::read_to_string(expand_tilde(path)) {
-                        Ok(content) => Ok((path.to_string(), content)),
-                        Err(err) => Err(CommandError::CannotReadFile {
-                            path: path.clone(),
-                            os_error: err.to_string(),
-                        }),
+                #[cfg(unix)]
+                let stdin = String::from("/dev/stdin");
+
+                let program = {
+                    let mut program = Vec::with_capacity(files.len());
+                for file in files
+                    .iter()
+                    .map(|&name| {
+                        let mut name = name;
+                        #[cfg(unix)]
+                        if name == "-" {
+                            name = &stdin;
+                        }
+
+                        match std::fs::read_to_string(expand_tilde(name)) {
+                            Ok(content) => Ok((name.to_string(), content)),
+                            Err(err) => Err(CommandError::CannotReadFile {
+                                path: name.to_string(),
+                                os_error: err.to_string(),
+                            }),
+                        }
+                    }) {
+                        program.push(file?)
                     }
-                })
-                .collect::<Result<_, _>>()?;
+                    program
+                };
 
-            state.program = Some(program);
-            let program = state.program.as_ref().unwrap();
+                state.program = Some(program);
+                let program = state.program.as_ref().unwrap();
 
-            let binary_files = program
-                .iter()
-                .map(|(path, file)| TaggedFile::new(Some(path), file))
-                .collect::<Vec<_>>();
+                let binary_files = program
+                    .iter()
+                    .map(|(path, file)| TaggedFile::new(Some(path), file))
+                    .collect();
 
-            let binary = mipsy_lib::compile(
-                &state.iset,
-                binary_files,
-                &CompilerOptions::default(),
-                &state.config,
-            )
-            .map_err(|err| CommandError::CannotCompile { mipsy_error: err })?;
+                let binary = mipsy_lib::compile(
+                    &state.iset,
+                    binary_files,
+                    &CompilerOptions::default(),
+                    &state.config,
+                )
+                    .map_err(|err| CommandError::CannotCompile { mipsy_error: err })?;
 
-            let runtime =
-                mipsy_lib::runtime(&binary, &arguments.iter().map(|x| &**x).collect::<Vec<_>>());
+                let runtime = mipsy_lib::runtime(&binary, arguments);
 
-            state.binary = Some(binary);
-            state.runtime = runtime;
-            state.exited = false;
+                state.binary = Some(binary);
+                state.runtime = runtime;
+                state.exited = false;
 
-            let loaded = if program.len() == 1 {
-                "file loaded"
-            } else {
-                "files loaded"
-            };
+                let loaded = if program.len() == 1 {
+                    "file loaded"
+                } else {
+                    "files loaded"
+                };
 
-            prompt::success_nl(loaded);
+                prompt::success_nl(loaded);
 
-            Ok("".into())
-        },
+                Ok("".into())
+            },
     )
 }

--- a/crates/mipsy_interactive/src/interactive/commands/load.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/load.rs
@@ -21,100 +21,96 @@ pub(crate) fn command() -> Command {
                     } else {
                         Err(CommandError::BadArgument {
                             arg: "file".to_owned(),
-                            instead: a.to_owned()
+                            instead: a.to_owned(),
                         })
                     }
                 },
-                |a, h| h.file_hints(a)
-            )
+                |a, h| h.file_hints(a),
+            ),
         )
-        .with_varargs_format(
-            "-- {args}".magenta().to_string()
-        )
+        .with_varargs_format("-- {args}".magenta().to_string())
         .with_desc("load a MIPS file to run")
-        .with_exec(
-            |_, state, _, label, args| {
-                if label == "__help__" {
-                    return Ok(
-                        format!(
-                            "Loads a MIPS file to run, overwriting whatever is currently loaded.\n\
-                            This command must be run prior to many others, such as `{}`, `{}`, `{}`, ...",
-                            "run".bold(),
-                            "step".bold(),
-                            "print".bold(),
-                        ),
-                    );
-                }
+        .with_help(format!(
+            "Loads a MIPS file to run, overwriting whatever is currently loaded.\n\
+                This command must be run prior to many others, such as `{}`, `{}`, `{}`, ...",
+            "run".bold(),
+            "step".bold(),
+            "print".bold(),
+        ))
+        .with_exec(|_, state, _, args| {
+            let args = &args_text(args)[..];
 
-                let args = &args_text(args)[..];
+            let (files, arguments) = {
+                if let Some(index) = args.iter().position(|arg| arg == "--") {
+                    let (files, arguments) = args.split_at(index);
 
-                let (files, arguments) = {
-                    if let Some(index) = args.iter().position(|arg| arg == "--") {
-                        let (files, arguments) = args.split_at(index);
-
-                        (files, &arguments[1..])
-                    } else {
-                        (args, &[][..])
-                    }
-                };
-
-                #[cfg(unix)]
-                let stdin = String::from("/dev/stdin");
-
-                let program = {
-                    let mut program = Vec::with_capacity(files.len());
-                for file in files
-                    .iter()
-                    .map(|mut name| {
-                        #[cfg(unix)]
-                        if name == "-" {
-                            name = &stdin;
-                        }
-
-                        match std::fs::read_to_string(expand_tilde(name)) {
-                            Ok(content) => Ok((name.to_string(), content)),
-                            Err(err) => Err(CommandError::CannotReadFile {
-                                path: name.to_string(),
-                                os_error: err.to_string(),
-                            }),
-                        }
-                    }) {
-                        program.push(file?)
-                    }
-                    program
-                };
-
-                state.program = Some(program);
-                let program = state.program.as_ref().unwrap();
-
-                let binary_files = program
-                    .iter()
-                    .map(|(path, file)| TaggedFile::new(Some(path), file))
-                    .collect();
-
-                let binary = mipsy_lib::compile(
-                    &state.iset,
-                    binary_files,
-                    &CompilerOptions::default(),
-                    &state.config,
-                )
-                    .map_err(|err| CommandError::CannotCompile { mipsy_error: err })?;
-
-                let runtime = mipsy_lib::runtime(&binary, arguments.iter().map(String::as_str).collect::<Vec<_>>().as_slice());
-
-                state.binary = Some(binary);
-                state.runtime = runtime;
-                state.exited = false;
-
-                let loaded = if program.len() == 1 {
-                    "file loaded"
+                    (files, &arguments[1..])
                 } else {
-                    "files loaded"
-                };
+                    (args, &[][..])
+                }
+            };
 
-                prompt::success_nl(loaded);
+            #[cfg(unix)]
+            let stdin = String::from("/dev/stdin");
 
-                Ok("".into())
-            },
-    )
+            let program = {
+                let mut program = Vec::with_capacity(files.len());
+                for file in files.iter().map(|mut name| {
+                    #[cfg(unix)]
+                    if name == "-" {
+                        name = &stdin;
+                    }
+
+                    match std::fs::read_to_string(expand_tilde(name)) {
+                        Ok(content) => Ok((name.to_string(), content)),
+                        Err(err) => Err(CommandError::CannotReadFile {
+                            path: name.to_string(),
+                            os_error: err.to_string(),
+                        }),
+                    }
+                }) {
+                    program.push(file?)
+                }
+                program
+            };
+
+            state.program = Some(program);
+            let program = state.program.as_ref().unwrap();
+
+            let binary_files = program
+                .iter()
+                .map(|(path, file)| TaggedFile::new(Some(path), file))
+                .collect();
+
+            let binary = mipsy_lib::compile(
+                &state.iset,
+                binary_files,
+                &CompilerOptions::default(),
+                &state.config,
+            )
+            .map_err(|err| CommandError::CannotCompile { mipsy_error: err })?;
+
+            let runtime = mipsy_lib::runtime(
+                &binary,
+                arguments
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+            );
+
+            state.binary = Some(binary);
+            state.runtime = runtime;
+            state.exited = false;
+
+            let loaded = if program.len() == 1 {
+                "file loaded"
+            } else {
+                "files loaded"
+            };
+
+            prompt::success_nl(loaded);
+
+            Ok("".into())
+        })
 }

--- a/crates/mipsy_interactive/src/interactive/commands/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/mod.rs
@@ -18,7 +18,12 @@ pub(super) mod run;
 pub(super) mod step;
 pub(super) mod watchpoint;
 
-use crate::interactive::helper::{HintArgs, MyHelper};
+use colored::Colorize;
+
+use crate::interactive::{
+    error::CommandError,
+    helper::{HintArgs, MyHelper},
+};
 
 use super::{error::CommandResult, State};
 
@@ -120,8 +125,8 @@ pub(crate) struct Command {
     pub(crate) names: Vec<String>,
     pub(crate) args: Arguments,
     description: String,
-    _internal_exec:
-        fn(&Command, &mut State, &MyHelper, &str, &[ArgumentKind]) -> CommandResult<String>,
+    help: String,
+    _internal_exec: fn(&Command, &mut State, &MyHelper, &[ArgumentKind]) -> CommandResult<String>,
     subcommands: Vec<Command>,
 }
 
@@ -159,20 +164,40 @@ impl Command {
         }
     }
 
+    pub(super) fn required_args(&self) -> &[Argument] {
+        match &self.args {
+            Arguments::Exactly { required, .. } => required,
+            Arguments::VarArgs { required, .. } => required,
+        }
+    }
+
     pub(crate) fn exec(
         &self,
         state: &mut State,
         helper: &MyHelper,
-        label: &str,
         args: &[String],
     ) -> CommandResult<String> {
-        (self._internal_exec)(
-            self,
-            state,
-            helper,
-            label,
-            self.args_from_strings(args, &helper)?.as_slice(),
-        )
+        let required = self.required_args();
+        if args.len() < required.len() {
+            Err(CommandError::WithTip {
+                error: Box::new(CommandError::MissingArguments {
+                    args: required
+                        .iter()
+                        .map(Argument::name)
+                        .map(str::to_owned)
+                        .collect(),
+                    instead: args.to_vec(),
+                }),
+                tip: format!("try `{} {}`", "help".bold(), self.name().bold()),
+            })
+        } else {
+            (self._internal_exec)(
+                self,
+                state,
+                helper,
+                self.args_from_strings(args, &helper)?.as_slice(),
+            )
+        }
     }
 
     pub(crate) fn new() -> Self {
@@ -183,7 +208,8 @@ impl Command {
                 optional: Default::default(),
             },
             description: Default::default(),
-            _internal_exec: |_, _, _, _, _| Ok(Default::default()),
+            help: Default::default(),
+            _internal_exec: |_, _, _, _| Ok(Default::default()),
             subcommands: Default::default(),
         }
     }
@@ -197,8 +223,13 @@ impl Command {
         self
     }
 
-    pub(crate) fn with_desc<S: Into<String>>(mut self, name: S) -> Self {
-        self.description = name.into();
+    pub(crate) fn with_desc<S: Into<String>>(mut self, desc: S) -> Self {
+        self.description = desc.into();
+        self
+    }
+
+    pub(crate) fn with_help<S: Into<String>>(mut self, help: S) -> Self {
+        self.help = help.into();
         self
     }
 
@@ -209,13 +240,7 @@ impl Command {
 
     pub(crate) fn with_exec(
         mut self,
-        exec: fn(
-            &Command,
-            &mut State,
-            helper: &MyHelper,
-            &str,
-            &[ArgumentKind],
-        ) -> CommandResult<String>,
+        exec: fn(&Command, &mut State, helper: &MyHelper, &[ArgumentKind]) -> CommandResult<String>,
     ) -> Self {
         self._internal_exec = exec;
         self

--- a/crates/mipsy_interactive/src/interactive/commands/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/mod.rs
@@ -20,6 +20,8 @@ pub(super) mod run;
 pub(super) mod step;
 pub(super) mod watchpoint;
 
+use crate::interactive::helper::{HintArgs, MyHelper};
+
 use super::{error::CommandResult, State};
 
 // TODO: remove once if-let chaining is in
@@ -54,27 +56,55 @@ impl From<ArgumentKind> for String {
     }
 }
 
-// TODO: maybe this should be a trait actually. oh well
+// TODO: another callback for __help__ label?
 // TODO: remove once if-let chaining is in
 #[derive(Clone)]
 pub(crate) struct Argument {
     name: String,
     sanitiser: fn(arg: &str) -> CommandResult<ArgumentKind>,
+    hints: fn(harg: &HintArgs, helper: &MyHelper) -> Vec<String>,
 }
 
 impl Argument {
     fn new<S: Into<String>>(
         name: S,
         sanitiser: fn(arg: &str) -> CommandResult<ArgumentKind>,
+        hints: fn(harg: &HintArgs, helper: &MyHelper) -> Vec<String>,
     ) -> Self {
         Self {
             name: name.into(),
             sanitiser,
+            hints,
         }
     }
 
     pub(crate) fn name(&self) -> &str {
         &self.name
+    }
+
+    pub(crate) fn hints(&self, mut harg: HintArgs, helper: &MyHelper) -> Vec<String> {
+        helper
+            .closest_hints(
+                &(self.hints)(&harg, helper)
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>(),
+                &harg.subcmd(),
+            )
+            .iter()
+            .map(|s| harg.recontextualize(s))
+            .collect::<Vec<_>>()
+    }
+
+    pub(crate) fn subcommands() -> Self {
+        Argument::new(
+            "subcommand",
+            |a| {
+                // TODO: match with subcmd hints
+                Ok(ArgumentKind::SubCommand(a.to_owned()))
+            },
+            |_, _| vec![],
+        )
     }
 }
 
@@ -83,7 +113,6 @@ impl Argument {
 pub(crate) enum Arguments {
     Exactly {
         required: Vec<Argument>,
-        // TODO: default values
         optional: Vec<Argument>,
     },
     VarArgs {
@@ -121,6 +150,16 @@ impl Command {
         Ok(res)
     }
 
+    pub(crate) fn args(&self) -> Vec<&Argument> {
+        match &self.args {
+            Arguments::Exactly { required, optional } => {
+                required.iter().chain(optional.iter()).collect::<Vec<_>>()
+            }
+            // TODO: varargs
+            Arguments::VarArgs { required, .. } => required.iter().collect(),
+        }
+    }
+
     pub(crate) fn exec(
         &self,
         state: &mut State,
@@ -141,6 +180,10 @@ impl Command {
             _internal_exec: |_, _, _, _| Ok(Default::default()),
             subcommands: Default::default(),
         }
+    }
+
+    pub(crate) fn name(&self) -> &str {
+        &self.names.get(0).expect("command has no name")
     }
 
     pub(crate) fn with_name<S: Into<String>>(mut self, name: S) -> Self {

--- a/crates/mipsy_interactive/src/interactive/commands/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/mod.rs
@@ -1,8 +1,6 @@
 #[allow(clippy::module_inception)]
 pub(crate) mod util;
 
-use std::fmt::Display;
-
 pub(super) mod breakpoint;
 pub(super) mod commands;
 pub(super) mod context;
@@ -28,31 +26,26 @@ use super::{error::CommandResult, State};
 #[derive(Clone)]
 pub(crate) enum ArgumentKind {
     Number(i64),
-    File(String),
-    Label(String),
-    Item(String),
-    Command(String),
-    SubCommand(String),
-    Any(String),
-}
-
-impl Display for ArgumentKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Number(_) => write!(f, "Number"),
-            Self::File(_) => write!(f, "File"),
-            Self::Label(_) => write!(f, "Label"),
-            Self::Item(_) => write!(f, "Item"),
-            Self::Command(_) => write!(f, "Command"),
-            Self::SubCommand(_) => write!(f, "Sub command"),
-            Self::Any(_) => write!(f, "Any"),
-        }
-    }
+    String(String),
 }
 
 impl From<ArgumentKind> for String {
     fn from(value: ArgumentKind) -> Self {
-        format!("{value}")
+        if let ArgumentKind::String(s) = value {
+            s
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+impl From<ArgumentKind> for i64 {
+    fn from(value: ArgumentKind) -> Self {
+        if let ArgumentKind::Number(n) = value {
+            n
+        } else {
+            unreachable!()
+        }
     }
 }
 
@@ -61,14 +54,14 @@ impl From<ArgumentKind> for String {
 #[derive(Clone)]
 pub(crate) struct Argument {
     name: String,
-    sanitiser: fn(arg: &str) -> CommandResult<ArgumentKind>,
+    sanitiser: fn(arg: &str, helper: &MyHelper) -> CommandResult<ArgumentKind>,
     hints: fn(harg: &HintArgs, helper: &MyHelper) -> Vec<String>,
 }
 
 impl Argument {
     fn new<S: Into<String>>(
         name: S,
-        sanitiser: fn(arg: &str) -> CommandResult<ArgumentKind>,
+        sanitiser: fn(arg: &str, helper: &MyHelper) -> CommandResult<ArgumentKind>,
         hints: fn(harg: &HintArgs, helper: &MyHelper) -> Vec<String>,
     ) -> Self {
         Self {
@@ -82,7 +75,7 @@ impl Argument {
         &self.name
     }
 
-    pub(crate) fn hints(&self, mut harg: HintArgs, helper: &MyHelper) -> Vec<String> {
+    pub(crate) fn hints(&self, harg: &HintArgs, helper: &MyHelper) -> Vec<String> {
         helper
             .closest_hints(
                 &(self.hints)(&harg, helper)
@@ -93,15 +86,15 @@ impl Argument {
             )
             .iter()
             .map(|s| harg.recontextualize(s))
-            .collect::<Vec<_>>()
+            .collect()
     }
 
     pub(crate) fn subcommands() -> Self {
         Argument::new(
             "subcommand",
-            |a| {
+            |a, _| {
                 // TODO: match with subcmd hints
-                Ok(ArgumentKind::SubCommand(a.to_owned()))
+                Ok(ArgumentKind::String(a.to_owned()))
             },
             |_, _| vec![],
         )
@@ -127,22 +120,28 @@ pub(crate) struct Command {
     pub(crate) names: Vec<String>,
     pub(crate) args: Arguments,
     description: String,
-    _internal_exec: fn(&Command, &mut State, &str, &[ArgumentKind]) -> CommandResult<String>,
+    _internal_exec:
+        fn(&Command, &mut State, &MyHelper, &str, &[ArgumentKind]) -> CommandResult<String>,
     subcommands: Vec<Command>,
 }
 
 impl Command {
-    fn args_from_strings(&self, args: &[String]) -> CommandResult<Vec<ArgumentKind>> {
+    fn args_from_strings(
+        &self,
+        args: &[String],
+        helper: &MyHelper,
+    ) -> CommandResult<Vec<ArgumentKind>> {
         let mut res = Vec::with_capacity(args.len());
         for arg in args.iter().flat_map(|strarg| match &self.args {
             Arguments::Exactly { required, optional } => required
                 .iter()
-                .map(|a| (a.sanitiser)(strarg))
-                .chain(optional.iter().map(|a| (a.sanitiser)(strarg)))
+                .map(|a| (a.sanitiser)(strarg, helper))
+                .chain(optional.iter().map(|a| (a.sanitiser)(strarg, helper)))
                 .collect::<Vec<CommandResult<ArgumentKind>>>(),
-            Arguments::VarArgs { required, .. } => {
-                required.iter().map(|a| (a.sanitiser)(strarg)).collect()
-            }
+            Arguments::VarArgs { required, .. } => required
+                .iter()
+                .map(|a| (a.sanitiser)(strarg, helper))
+                .collect(),
         }) {
             res.push(arg?)
         }
@@ -163,10 +162,17 @@ impl Command {
     pub(crate) fn exec(
         &self,
         state: &mut State,
+        helper: &MyHelper,
         label: &str,
         args: &[String],
     ) -> CommandResult<String> {
-        (self._internal_exec)(self, state, label, self.args_from_strings(args)?.as_slice())
+        (self._internal_exec)(
+            self,
+            state,
+            helper,
+            label,
+            self.args_from_strings(args, &helper)?.as_slice(),
+        )
     }
 
     pub(crate) fn new() -> Self {
@@ -177,7 +183,7 @@ impl Command {
                 optional: Default::default(),
             },
             description: Default::default(),
-            _internal_exec: |_, _, _, _| Ok(Default::default()),
+            _internal_exec: |_, _, _, _, _| Ok(Default::default()),
             subcommands: Default::default(),
         }
     }
@@ -203,7 +209,13 @@ impl Command {
 
     pub(crate) fn with_exec(
         mut self,
-        exec: fn(&Command, &mut State, &str, &[ArgumentKind]) -> CommandResult<String>,
+        exec: fn(
+            &Command,
+            &mut State,
+            helper: &MyHelper,
+            &str,
+            &[ArgumentKind],
+        ) -> CommandResult<String>,
     ) -> Self {
         self._internal_exec = exec;
         self

--- a/crates/mipsy_interactive/src/interactive/commands/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/mod.rs
@@ -32,99 +32,115 @@ use super::{error::CommandResult, State};
 pub(crate) enum ArgumentKind {
     Number(i64),
     String(String),
+    Correct,
 }
 
-impl From<ArgumentKind> for String {
-    fn from(value: ArgumentKind) -> Self {
+impl TryFrom<ArgumentKind> for String {
+    type Error = String;
+    fn try_from(value: ArgumentKind) -> Result<String, Self::Error> {
         match value {
-            ArgumentKind::String(s) => s,
-            ArgumentKind::Number(_) => unreachable!("tried to interpret as a string but argument was sanitised into a number")
+            ArgumentKind::String(s) => Ok(s),
+            _ => Err(format!(
+                "tried to interpret argument as a string but argument was not sanitised into a string"
+            )),
         }
     }
 }
 
-impl From<ArgumentKind> for i64 {
-    fn from(value: ArgumentKind) -> Self {
+impl TryFrom<ArgumentKind> for i64 {
+    type Error = String;
+    fn try_from(value: ArgumentKind) -> Result<i64, String> {
         match value {
-            ArgumentKind::Number(n) => n,
-            ArgumentKind::String(_) => unreachable!("tried to interpret as a number but argument was sanitised into a string")
+            ArgumentKind::Number(n) => Ok(n),
+            _ => Err(format!(
+                "tried to interpret argument as a number but argument was not sanitised into a number"
+            )),
         }
     }
 }
 
 // TODO: remove cmd callback params. find another way because currently its only use is for getting subcommands
+type Sanitiser = fn(arg: &str, helper: &MyHelper) -> CommandResult<ArgumentKind>;
+type Hints = fn(harg: &HintArgs, helper: &MyHelper) -> Vec<String>;
 // TODO: remove once if-let chaining is in
 #[derive(Clone, Debug)]
-pub(crate) struct Argument {
-    name: String,
-    sanitiser: fn(cmd: &Command, arg: &str, helper: &MyHelper) -> CommandResult<ArgumentKind>,
-    hints: fn(cmd: &Command, harg: &HintArgs, helper: &MyHelper) -> Vec<String>,
+pub(crate) enum Argument {
+    Normal {
+        name: String,
+        sanitiser: Sanitiser,
+        hints: Hints,
+    },
+    Subcommand,
 }
 
 impl Argument {
-    fn new<S: Into<String>>(
-        name: S,
-        sanitiser: fn(cmd: &Command, arg: &str, helper: &MyHelper) -> CommandResult<ArgumentKind>,
-        hints: fn(cmd: &Command, harg: &HintArgs, helper: &MyHelper) -> Vec<String>,
-    ) -> Self {
-        Self {
+    fn new(name: impl Into<String>, sanitiser: Sanitiser, hints: Hints) -> Self {
+        Self::Normal {
             name: name.into(),
             sanitiser,
             hints,
         }
     }
 
+    fn sanitiser<'a, 'b: 'a>(
+        &'a self,
+        cmd: &'b Command,
+    ) -> Box<dyn FnMut(&'a str, &'b MyHelper) -> CommandResult<ArgumentKind> + 'a> {
+        match self {
+            Argument::Normal { sanitiser, .. } => Box::new(sanitiser),
+            Argument::Subcommand => Box::new(|a: &str, _| {
+                match cmd
+                    .subcommands
+                    .iter()
+                    .flat_map(|c| &c.names)
+                    .find(|&s| s == &a)
+                {
+                    Some(_) => Ok(ArgumentKind::Correct),
+                    None => Err(CommandError::BadArgument {
+                        arg: "any subcommand".to_owned(),
+                        instead: a.to_owned(),
+                    }),
+                }
+            }),
+        }
+    }
+
     pub(crate) fn from_name(name: impl Into<String>) -> Self {
         Argument::new(
             name,
-            |_, a, _| Ok(ArgumentKind::String(a.to_owned())),
-            |_, _, _| vec![],
+            |a, _| Ok(ArgumentKind::String(a.to_owned())),
+            |_, _| vec![],
         )
     }
 
     pub(crate) fn name(&self) -> &str {
-        &self.name
+        match self {
+            Self::Normal { name, .. } => name,
+            Self::Subcommand => "subcommand",
+        }
     }
 
     pub(crate) fn hints(&self, cmd: &Command, harg: &HintArgs, helper: &MyHelper) -> Vec<String> {
         helper
             .closest_hints(
-                &(self.hints)(cmd, &harg, helper)
-                    .iter()
-                    .map(String::as_str)
-                    .collect::<Vec<_>>(),
+                match self {
+                    Self::Normal { hints, .. } => hints(&harg, helper),
+                    Self::Subcommand => cmd
+                        .subcommands
+                        .iter()
+                        .map(Command::name)
+                        .map(str::to_owned)
+                        .collect(),
+                }
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .as_slice(),
                 &harg.subcmd(),
             )
             .iter()
             .map(|s| harg.recontextualize(s))
             .collect()
-    }
-
-    // TODO: remove command param from callback and have a seperate argument
-    //       allowing us to forward arguments to subcommand params
-    pub(crate) fn subcommands() -> Self {
-        Argument::new(
-            "subcommand",
-            |c, a, _| match c
-                .subcommands
-                .iter()
-                .flat_map(|c| &c.names)
-                .find(|&s| s == a)
-            {
-                Some(_) => Ok(ArgumentKind::String(a.to_owned())),
-                None => Err(CommandError::BadArgument {
-                    arg: "any subcommand".to_owned(),
-                    instead: a.to_owned(),
-                }),
-            },
-            |c, _, _| {
-                c.subcommands
-                    .iter()
-                    .map(Command::name)
-                    .map(str::to_owned)
-                    .collect()
-            },
-        )
     }
 }
 
@@ -158,40 +174,64 @@ impl Command {
         args: &[String],
         helper: &MyHelper,
     ) -> CommandResult<Vec<ArgumentKind>> {
+        let mut optional_sans: Vec<_> = match &self.args {
+            Arguments::Exactly { optional, .. } => {
+                optional.iter().map(|arg| arg.sanitiser(self)).collect()
+            }
+            Arguments::VarArgs { required, variadic } => {
+                std::iter::repeat_n(variadic, (args.len() - required.len()) + 1)
+                    .map(|v| v.sanitiser(self))
+                    .collect()
+            }
+        };
+
+        // required args must be zipped with their sanitisers
+        // optional args, however, are able to pick which sanitiser they work with
+        // e.g.
+        //      for 'step 1' and 'step back' comamnds, the count num and subcommand
+        //      arguments are both optional, so when supplying 'back' it must choose
+        //      a sanitiser which works (the subcommand sanitiser) instead of zipping
+        //      which would result in 'back' being sanitised as the count num argument
+
+        // only to please the borrow checker, this could be expressed more logically by
+        // making `optional_sans` a mutable iterator if it were possible:(
+        let mut skip = 0;
+
+        println!("hi");
         args.iter()
-            .zip(match &self.args {
-                Arguments::Exactly { required, optional } => required
+            .zip(self.required_args())
+            .map(|(strarg, arg)| (arg.sanitiser(self))(strarg, helper))
+            .chain(
+                args
                     .iter()
-                    .map(|a| a.sanitiser)
-                    .chain(optional.iter().map(|a| a.sanitiser))
-                    // TODO: this isnt great, we assume the last argument is a subcommand
-                    // and forward its args. not an ideal solution.
-                    //       a better way would be to have an explicit subcommand
-                    //       argument type but that would make the usual normal arguments
-                    //       clunky
-                    .chain(std::iter::repeat_n(
-                        (|_, a, _| Ok(ArgumentKind::String(a.to_owned())))
-                        as fn(cmd: &Command, arg: &str, helper: &MyHelper) -> CommandResult<ArgumentKind>
-                    , args.len() - required.len()))
-                    .collect::<Vec<_>>(),
-                Arguments::VarArgs { required, variadic } => required
-                    .iter()
-                    .map(|a| a.sanitiser)
-                    .chain(std::iter::repeat_n(
-                        variadic.sanitiser,
-                        (args.len() - required.len()) + 1,
-                    ))
-                    .collect(),
-            })
-            // TODO: give varargs the whole arg instead of `strarg`
-            .map(|(strarg, san)| san(self, strarg, helper))
+                    .skip(self.required_args().len())
+                    // TODO: give varargs the whole arg instead of just one `strarg`
+                    .map(|strarg| {
+                        println!("{skip}");
+                        let (skipped, san) = optional_sans
+                            .iter_mut()
+                            .map(|san| san(strarg, helper))
+                            .skip(skip)
+                            .enumerate()
+                            .skip_while(|(_, san)| san.is_err())
+                            .next()
+                            .map_or(
+                                (1, optional_sans.iter_mut().nth(skip).expect(
+                                    "somehow there are not enough input sanitisers left (impossible)",
+                                )(strarg, helper)),
+                                |(skipped, san)| (skipped + 1, san)
+                            );
+                        skip += skipped;
+                        san
+                    }),
+            )
             .collect()
     }
 
     pub(crate) fn args(&self, vararg_count: usize) -> Vec<&Argument> {
         match &self.args {
             Arguments::Exactly { required, optional } => {
-                required.iter().chain(optional.iter()).collect::<Vec<_>>()
+                required.iter().chain(optional.iter()).collect()
             }
             Arguments::VarArgs { required, variadic } => required
                 .iter()
@@ -211,7 +251,8 @@ impl Command {
         if args.len() < self.required_args().len() {
             Err(CommandError::WithTip {
                 error: Box::new(CommandError::MissingArguments {
-                    args: self.required_args()
+                    args: self
+                        .required_args()
                         .iter()
                         .map(Argument::name)
                         .map(str::to_owned)
@@ -224,11 +265,7 @@ impl Command {
             // TODO this is not great, it assumes that the last argument is a subcommand
             // and will forward all the arguments to them
 
-            (self._internal_exec)(
-                self,
-                helper,
-                &self.sanitise_args(args, &helper)?
-            )
+            (self._internal_exec)(self, helper, &self.sanitise_args(args, &helper)?)
         }
     }
 

--- a/crates/mipsy_interactive/src/interactive/commands/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/mod.rs
@@ -54,20 +54,20 @@ impl From<ArgumentKind> for i64 {
     }
 }
 
-// TODO: another callback for __help__ label?
+// TODO: remove cmd callback params. find another way because currently its only use is for getting subcommands
 // TODO: remove once if-let chaining is in
 #[derive(Clone)]
 pub(crate) struct Argument {
     name: String,
-    sanitiser: fn(arg: &str, helper: &MyHelper) -> CommandResult<ArgumentKind>,
-    hints: fn(harg: &HintArgs, helper: &MyHelper) -> Vec<String>,
+    sanitiser: fn(cmd: &Command, arg: &str, helper: &MyHelper) -> CommandResult<ArgumentKind>,
+    hints: fn(cmd: &Command, harg: &HintArgs, helper: &MyHelper) -> Vec<String>,
 }
 
 impl Argument {
     fn new<S: Into<String>>(
         name: S,
-        sanitiser: fn(arg: &str, helper: &MyHelper) -> CommandResult<ArgumentKind>,
-        hints: fn(harg: &HintArgs, helper: &MyHelper) -> Vec<String>,
+        sanitiser: fn(cmd: &Command, arg: &str, helper: &MyHelper) -> CommandResult<ArgumentKind>,
+        hints: fn(cmd: &Command, harg: &HintArgs, helper: &MyHelper) -> Vec<String>,
     ) -> Self {
         Self {
             name: name.into(),
@@ -80,10 +80,10 @@ impl Argument {
         &self.name
     }
 
-    pub(crate) fn hints(&self, harg: &HintArgs, helper: &MyHelper) -> Vec<String> {
+    pub(crate) fn hints(&self, cmd: &Command, harg: &HintArgs, helper: &MyHelper) -> Vec<String> {
         helper
             .closest_hints(
-                &(self.hints)(&harg, helper)
+                &(self.hints)(cmd, &harg, helper)
                     .iter()
                     .map(String::as_str)
                     .collect::<Vec<_>>(),
@@ -97,11 +97,19 @@ impl Argument {
     pub(crate) fn subcommands() -> Self {
         Argument::new(
             "subcommand",
-            |a, _| {
-                // TODO: match with subcmd hints
-                Ok(ArgumentKind::String(a.to_owned()))
+            |c, a, _| match c
+                .subcommands
+                .iter()
+                .flat_map(|c| &c.names)
+                .find(|&s| s == &a.to_owned())
+            {
+                Some(_) => Ok(ArgumentKind::String(a.to_owned())),
+                None => Err(CommandError::BadArgument {
+                    arg: "any subcommand".to_owned(),
+                    instead: a.to_owned(),
+                }),
             },
-            |_, _| vec![],
+            |c, _, _| c.subcommands.iter().map(Command::name).map(str::to_owned).collect(),
         )
     }
 }
@@ -140,12 +148,12 @@ impl Command {
         for arg in args.iter().flat_map(|strarg| match &self.args {
             Arguments::Exactly { required, optional } => required
                 .iter()
-                .map(|a| (a.sanitiser)(strarg, helper))
-                .chain(optional.iter().map(|a| (a.sanitiser)(strarg, helper)))
+                .map(|a| (a.sanitiser)(self, strarg, helper))
+                .chain(optional.iter().map(|a| (a.sanitiser)(self, strarg, helper)))
                 .collect::<Vec<CommandResult<ArgumentKind>>>(),
             Arguments::VarArgs { required, .. } => required
                 .iter()
-                .map(|a| (a.sanitiser)(strarg, helper))
+                .map(|a| (a.sanitiser)(self, strarg, helper))
                 .collect(),
         }) {
             res.push(arg?)

--- a/crates/mipsy_interactive/src/interactive/commands/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/mod.rs
@@ -28,7 +28,7 @@ use crate::interactive::{
 use super::{error::CommandResult, State};
 
 // TODO: remove once if-let chaining is in
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) enum ArgumentKind {
     Number(i64),
     String(String),
@@ -56,7 +56,7 @@ impl From<ArgumentKind> for i64 {
 
 // TODO: remove cmd callback params. find another way because currently its only use is for getting subcommands
 // TODO: remove once if-let chaining is in
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct Argument {
     name: String,
     sanitiser: fn(cmd: &Command, arg: &str, helper: &MyHelper) -> CommandResult<ArgumentKind>,
@@ -109,13 +109,19 @@ impl Argument {
                     instead: a.to_owned(),
                 }),
             },
-            |c, _, _| c.subcommands.iter().map(Command::name).map(str::to_owned).collect(),
+            |c, _, _| {
+                c.subcommands
+                    .iter()
+                    .map(Command::name)
+                    .map(str::to_owned)
+                    .collect()
+            },
         )
     }
 }
 
 // TODO(joshh): remove once if-let chaining is in
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) enum Arguments {
     Exactly {
         required: Vec<Argument>,
@@ -128,13 +134,13 @@ pub(crate) enum Arguments {
 }
 
 // TODO(joshh): remove once if-let chaining is in
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct Command {
     pub(crate) names: Vec<String>,
     pub(crate) args: Arguments,
     description: String,
     help: String,
-    _internal_exec: fn(&Command, &mut State, &MyHelper, &[ArgumentKind]) -> CommandResult<String>,
+    _internal_exec: fn(&Command, &mut MyHelper, &[ArgumentKind]) -> CommandResult<String>,
     subcommands: Vec<Command>,
 }
 
@@ -179,12 +185,7 @@ impl Command {
         }
     }
 
-    pub(crate) fn exec(
-        &self,
-        state: &mut State,
-        helper: &MyHelper,
-        args: &[String],
-    ) -> CommandResult<String> {
+    pub(crate) fn exec(&self, helper: &mut MyHelper, args: &[String]) -> CommandResult<String> {
         let required = self.required_args();
         if args.len() < required.len() {
             Err(CommandError::WithTip {
@@ -201,7 +202,6 @@ impl Command {
         } else {
             (self._internal_exec)(
                 self,
-                state,
                 helper,
                 self.args_from_strings(args, &helper)?.as_slice(),
             )
@@ -217,7 +217,7 @@ impl Command {
             },
             description: Default::default(),
             help: Default::default(),
-            _internal_exec: |_, _, _, _| Ok(Default::default()),
+            _internal_exec: |_, _, _| Ok(Default::default()),
             subcommands: Default::default(),
         }
     }
@@ -248,7 +248,7 @@ impl Command {
 
     pub(crate) fn with_exec(
         mut self,
-        exec: fn(&Command, &mut State, helper: &MyHelper, &[ArgumentKind]) -> CommandResult<String>,
+        exec: fn(&Command, helper: &mut MyHelper, &[ArgumentKind]) -> CommandResult<String>,
     ) -> Self {
         self._internal_exec = exec;
         self

--- a/crates/mipsy_interactive/src/interactive/commands/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/mod.rs
@@ -39,7 +39,7 @@ impl From<ArgumentKind> for String {
         if let ArgumentKind::String(s) = value {
             s
         } else {
-            unreachable!()
+            unreachable!("tried to interpret as a string but argument was sanitised into a number")
         }
     }
 }
@@ -49,7 +49,7 @@ impl From<ArgumentKind> for i64 {
         if let ArgumentKind::Number(n) = value {
             n
         } else {
-            unreachable!()
+            unreachable!("tried to interpret as a number but argument was sanitised into a string")
         }
     }
 }
@@ -74,6 +74,14 @@ impl Argument {
             sanitiser,
             hints,
         }
+    }
+
+    pub(crate) fn from_name(name: impl Into<String>) -> Self {
+        Argument::new(
+            name,
+            |_, a, _| Ok(ArgumentKind::String(a.to_owned())),
+            |_, _, _| vec![]
+        )
     }
 
     pub(crate) fn name(&self) -> &str {
@@ -129,7 +137,7 @@ pub(crate) enum Arguments {
     },
     VarArgs {
         required: Vec<Argument>,
-        format: String,
+        variadic: Argument,
     },
 }
 
@@ -150,31 +158,30 @@ impl Command {
         args: &[String],
         helper: &MyHelper,
     ) -> CommandResult<Vec<ArgumentKind>> {
-        let mut res = Vec::with_capacity(args.len());
-        for arg in args.iter().flat_map(|strarg| match &self.args {
-            Arguments::Exactly { required, optional } => required
-                .iter()
-                .map(|a| (a.sanitiser)(self, strarg, helper))
-                .chain(optional.iter().map(|a| (a.sanitiser)(self, strarg, helper)))
-                .collect::<Vec<CommandResult<ArgumentKind>>>(),
-            Arguments::VarArgs { required, .. } => required
-                .iter()
-                .map(|a| (a.sanitiser)(self, strarg, helper))
-                .collect(),
-        }) {
-            res.push(arg?)
-        }
-
-        Ok(res)
+        args.iter()
+            .zip(match &self.args {
+                Arguments::Exactly { required, optional } => required
+                    .iter()
+                    .map(|a| a.sanitiser)
+                    .chain(optional.iter().map(|a| a.sanitiser))
+                    .collect::<Vec<_>>(),
+                Arguments::VarArgs { required, variadic } => required
+                    .iter()
+                    .map(|a| a.sanitiser)
+                    .chain(std::iter::repeat_n(variadic.sanitiser, (args.len() - required.len()) + 1))
+                    .collect(),
+            })
+            // TODO: give varargs the whole arg instead of `strarg`
+            .map(|(strarg, san)| san(self, strarg, helper))
+            .collect()
     }
 
-    pub(crate) fn args(&self) -> Vec<&Argument> {
+    pub(crate) fn args(&self, vararg_count: usize) -> Vec<&Argument> {
         match &self.args {
             Arguments::Exactly { required, optional } => {
                 required.iter().chain(optional.iter()).collect::<Vec<_>>()
             }
-            // TODO: varargs
-            Arguments::VarArgs { required, .. } => required.iter().collect(),
+            Arguments::VarArgs { required, variadic } => required.iter().chain(std::iter::repeat_n(variadic, vararg_count)).collect(),
         }
     }
 
@@ -254,18 +261,27 @@ impl Command {
         self
     }
 
-    pub(crate) fn with_exact_args(mut self) -> Self {
-        self.args = Arguments::Exactly {
+    /// NOTE: resets the argument kind to [`Arguments::VarArgs`]
+    ///       this resets any
+    ///         - [`Arguments::VarArgs::required`]
+    ///         - [`Arguments::Exactly::required`]
+    ///         - [`Arguments::Exactly::optional`]
+    ///       Argumets, so call this before adding any other arguments
+    ///       \
+    ///       The [`Argument::name`] of `arg` is set to the vararg format
+    ///       and the [`Argument::sanitiser`] and [`Argument::hints`] for variadic arguments
+    pub(crate) fn with_var_args(mut self, arg: Argument) -> Self {
+        self.args = Arguments::VarArgs {
             required: vec![],
-            optional: vec![],
+            variadic: arg
         };
         self
     }
 
-    pub(crate) fn with_var_args(mut self) -> Self {
-        self.args = Arguments::VarArgs {
+    pub(crate) fn with_exact_args(mut self) -> Self {
+        self.args = Arguments::Exactly {
             required: vec![],
-            format: Default::default(),
+            optional: vec![],
         };
         self
     }
@@ -289,17 +305,9 @@ impl Command {
             Arguments::Exactly {
                 ref mut optional, ..
             } => optional.push(arg),
-            Arguments::VarArgs { .. } => unreachable!(),
+            Arguments::VarArgs { .. } => unreachable!("tried to supply an optional argument while being in the VarArgs argument state\ntry use `self.with_exact_args()` to set the argument state"),
         }
 
-        self
-    }
-
-    pub(crate) fn with_varargs_format(mut self, vfmt: impl Into<String>) -> Self {
-        match self.args {
-            Arguments::VarArgs { ref mut format, .. } => *format = vfmt.into(),
-            Arguments::Exactly { .. } => unreachable!(),
-        }
         self
     }
 }

--- a/crates/mipsy_interactive/src/interactive/commands/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/mod.rs
@@ -1,49 +1,93 @@
-mod breakpoint;
 #[allow(clippy::module_inception)]
-mod commands;
-mod context;
-mod disassemble;
-mod dot;
-mod examine;
-mod exit;
-mod help;
-mod label;
-mod labels;
-mod load;
-mod print;
-mod reset;
-mod run;
-mod step;
 pub(crate) mod util;
-mod watchpoint;
 
-pub(crate) use breakpoint::breakpoint_command;
-pub(crate) use context::context_command;
-pub(crate) use disassemble::disassemble_command;
-pub(crate) use dot::dot_command;
-pub(crate) use examine::examine_command;
-pub(crate) use exit::exit_command;
-pub(crate) use help::help_command;
-pub(crate) use label::label_command;
-pub(crate) use labels::labels_command;
-pub(crate) use load::load_command;
-pub(crate) use print::print_command;
-pub(crate) use reset::reset_command;
-pub(crate) use run::run_command;
-pub(crate) use step::step_command;
-pub(crate) use watchpoint::watchpoint_command;
+use std::fmt::Display;
+
+pub(super) mod breakpoint;
+pub(super) mod commands;
+pub(super) mod context;
+pub(super) mod disassemble;
+pub(super) mod dot;
+pub(super) mod examine;
+pub(super) mod exit;
+pub(super) mod help;
+pub(super) mod label;
+pub(super) mod labels;
+pub(super) mod load;
+pub(super) mod print;
+pub(super) mod reset;
+pub(super) mod run;
+pub(super) mod step;
+pub(super) mod watchpoint;
 
 use super::{error::CommandResult, State};
+
+// TODO: remove once if-let chaining is in
+#[derive(Clone)]
+pub(crate) enum ArgumentKind {
+    Number(i64),
+    File(String),
+    Label(String),
+    Item(String),
+    Command(String),
+    SubCommand(String),
+    Any(String),
+}
+
+impl Display for ArgumentKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Number(_) => write!(f, "Number"),
+            Self::File(_) => write!(f, "File"),
+            Self::Label(_) => write!(f, "Label"),
+            Self::Item(_) => write!(f, "Item"),
+            Self::Command(_) => write!(f, "Command"),
+            Self::SubCommand(_) => write!(f, "Sub command"),
+            Self::Any(_) => write!(f, "Any"),
+        }
+    }
+}
+
+impl From<ArgumentKind> for String {
+    fn from(value: ArgumentKind) -> Self {
+        format!("{value}")
+    }
+}
+
+// TODO: maybe this should be a trait actually. oh well
+// TODO: remove once if-let chaining is in
+#[derive(Clone)]
+pub(crate) struct Argument {
+    name: String,
+    sanitiser: fn(arg: &str) -> CommandResult<ArgumentKind>,
+}
+
+impl Argument {
+    fn new<S: Into<String>>(
+        name: S,
+        sanitiser: fn(arg: &str) -> CommandResult<ArgumentKind>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            sanitiser,
+        }
+    }
+
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+}
 
 // TODO(joshh): remove once if-let chaining is in
 #[derive(Clone)]
 pub(crate) enum Arguments {
     Exactly {
-        required: Vec<String>,
-        optional: Vec<String>,
+        required: Vec<Argument>,
+        // TODO: default values
+        optional: Vec<Argument>,
     },
     VarArgs {
-        required: Vec<String>,
+        required: Vec<Argument>,
         format: String,
     },
 }
@@ -51,65 +95,123 @@ pub(crate) enum Arguments {
 // TODO(joshh): remove once if-let chaining is in
 #[derive(Clone)]
 pub(crate) struct Command {
-    pub(crate) name: String,
-    pub(crate) aliases: Vec<String>,
+    pub(crate) names: Vec<String>,
     pub(crate) args: Arguments,
     description: String,
-    _internal_exec: fn(&Command, &mut State, &str, &[String]) -> CommandResult<String>,
+    _internal_exec: fn(&Command, &mut State, &str, &[ArgumentKind]) -> CommandResult<String>,
     subcommands: Vec<Command>,
 }
 
 impl Command {
+    fn args_from_strings(&self, args: &[String]) -> CommandResult<Vec<ArgumentKind>> {
+        let mut res = Vec::with_capacity(args.len());
+        for arg in args.iter().flat_map(|strarg| match &self.args {
+            Arguments::Exactly { required, optional } => required
+                .iter()
+                .map(|a| (a.sanitiser)(strarg))
+                .chain(optional.iter().map(|a| (a.sanitiser)(strarg)))
+                .collect::<Vec<CommandResult<ArgumentKind>>>(),
+            Arguments::VarArgs { required, .. } => {
+                required.iter().map(|a| (a.sanitiser)(strarg)).collect()
+            }
+        }) {
+            res.push(arg?)
+        }
+
+        Ok(res)
+    }
+
     pub(crate) fn exec(
         &self,
         state: &mut State,
         label: &str,
         args: &[String],
     ) -> CommandResult<String> {
-        (self._internal_exec)(self, state, label, args)
+        (self._internal_exec)(self, state, label, self.args_from_strings(args)?.as_slice())
     }
-}
 
-pub(crate) fn command<S: Into<String>>(
-    name: S,
-    aliases: Vec<S>,
-    required_args: Vec<S>,
-    optional_args: Vec<S>,
-    subcommands: Vec<Command>,
-    desc: S,
-    exec: fn(&Command, &mut State, &str, &[String]) -> CommandResult<String>,
-) -> Command {
-    Command {
-        name: name.into(),
-        description: desc.into(),
-        aliases: aliases.into_iter().map(S::into).collect(),
-        args: Arguments::Exactly {
-            required: required_args.into_iter().map(S::into).collect(),
-            optional: optional_args.into_iter().map(S::into).collect(),
-        },
-        _internal_exec: exec,
-        subcommands,
+    pub(crate) fn new() -> Self {
+        Self {
+            names: Default::default(),
+            args: Arguments::Exactly {
+                required: Default::default(),
+                optional: Default::default(),
+            },
+            description: Default::default(),
+            _internal_exec: |_, _, _, _| Ok(Default::default()),
+            subcommands: Default::default(),
+        }
     }
-}
 
-pub(crate) fn command_varargs<S: Into<String>>(
-    name: S,
-    aliases: Vec<S>,
-    required_args: Vec<S>,
-    varargs_format: impl Into<String>,
-    subcommands: Vec<Command>,
-    desc: S,
-    exec: fn(&Command, &mut State, &str, &[String]) -> CommandResult<String>,
-) -> Command {
-    Command {
-        name: name.into(),
-        description: desc.into(),
-        aliases: aliases.into_iter().map(S::into).collect(),
-        args: Arguments::VarArgs {
-            required: required_args.into_iter().map(S::into).collect(),
-            format: varargs_format.into(),
-        },
-        _internal_exec: exec,
-        subcommands,
+    pub(crate) fn with_name<S: Into<String>>(mut self, name: S) -> Self {
+        self.names.push(name.into());
+        self
+    }
+
+    pub(crate) fn with_desc<S: Into<String>>(mut self, name: S) -> Self {
+        self.description = name.into();
+        self
+    }
+
+    pub(crate) fn with_subcommand(mut self, subcommands: Command) -> Self {
+        self.subcommands.push(subcommands);
+        self
+    }
+
+    pub(crate) fn with_exec(
+        mut self,
+        exec: fn(&Command, &mut State, &str, &[ArgumentKind]) -> CommandResult<String>,
+    ) -> Self {
+        self._internal_exec = exec;
+        self
+    }
+
+    pub(crate) fn with_exact_args(mut self) -> Self {
+        self.args = Arguments::Exactly {
+            required: vec![],
+            optional: vec![],
+        };
+        self
+    }
+
+    pub(crate) fn with_var_args(mut self) -> Self {
+        self.args = Arguments::VarArgs {
+            required: vec![],
+            format: Default::default(),
+        };
+        self
+    }
+
+    pub(crate) fn with_required_arg(mut self, arg: Argument) -> Self {
+        match self.args {
+            Arguments::Exactly {
+                ref mut required, ..
+            } => required,
+            Arguments::VarArgs {
+                ref mut required, ..
+            } => required,
+        }
+        .push(arg);
+
+        self
+    }
+
+    pub(crate) fn with_optional_arg(mut self, arg: Argument) -> Self {
+        match self.args {
+            Arguments::Exactly {
+                ref mut optional, ..
+            } => optional.push(arg),
+            Arguments::VarArgs { .. } => unreachable!(),
+        }
+
+        self
+    }
+
+    pub(crate) fn with_varargs_format(mut self, vfmt: impl Into<String>) -> Self {
+        match self.args {
+            Arguments::VarArgs { ref mut format, .. } => *format = vfmt.into(),
+            Arguments::Exactly { .. } => unreachable!(),
+        }
+        self
     }
 }

--- a/crates/mipsy_interactive/src/interactive/commands/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/mod.rs
@@ -36,20 +36,18 @@ pub(crate) enum ArgumentKind {
 
 impl From<ArgumentKind> for String {
     fn from(value: ArgumentKind) -> Self {
-        if let ArgumentKind::String(s) = value {
-            s
-        } else {
-            unreachable!("tried to interpret as a string but argument was sanitised into a number")
+        match value {
+            ArgumentKind::String(s) => s,
+            ArgumentKind::Number(_) => unreachable!("tried to interpret as a string but argument was sanitised into a number")
         }
     }
 }
 
 impl From<ArgumentKind> for i64 {
     fn from(value: ArgumentKind) -> Self {
-        if let ArgumentKind::Number(n) = value {
-            n
-        } else {
-            unreachable!("tried to interpret as a number but argument was sanitised into a string")
+        match value {
+            ArgumentKind::Number(n) => n,
+            ArgumentKind::String(_) => unreachable!("tried to interpret as a number but argument was sanitised into a string")
         }
     }
 }
@@ -80,7 +78,7 @@ impl Argument {
         Argument::new(
             name,
             |_, a, _| Ok(ArgumentKind::String(a.to_owned())),
-            |_, _, _| vec![]
+            |_, _, _| vec![],
         )
     }
 
@@ -102,6 +100,8 @@ impl Argument {
             .collect()
     }
 
+    // TODO: remove command param from callback and have a seperate argument
+    //       allowing us to forward arguments to subcommand params
     pub(crate) fn subcommands() -> Self {
         Argument::new(
             "subcommand",
@@ -109,7 +109,7 @@ impl Argument {
                 .subcommands
                 .iter()
                 .flat_map(|c| &c.names)
-                .find(|&s| s == &a.to_owned())
+                .find(|&s| s == a)
             {
                 Some(_) => Ok(ArgumentKind::String(a.to_owned())),
                 None => Err(CommandError::BadArgument {
@@ -153,7 +153,7 @@ pub(crate) struct Command {
 }
 
 impl Command {
-    fn args_from_strings(
+    fn sanitise_args(
         &self,
         args: &[String],
         helper: &MyHelper,
@@ -164,11 +164,23 @@ impl Command {
                     .iter()
                     .map(|a| a.sanitiser)
                     .chain(optional.iter().map(|a| a.sanitiser))
+                    // TODO: this isnt great, we assume the last argument is a subcommand
+                    // and forward its args. not an ideal solution.
+                    //       a better way would be to have an explicit subcommand
+                    //       argument type but that would make the usual normal arguments
+                    //       clunky
+                    .chain(std::iter::repeat_n(
+                        (|_, a, _| Ok(ArgumentKind::String(a.to_owned())))
+                        as fn(cmd: &Command, arg: &str, helper: &MyHelper) -> CommandResult<ArgumentKind>
+                    , args.len() - required.len()))
                     .collect::<Vec<_>>(),
                 Arguments::VarArgs { required, variadic } => required
                     .iter()
                     .map(|a| a.sanitiser)
-                    .chain(std::iter::repeat_n(variadic.sanitiser, (args.len() - required.len()) + 1))
+                    .chain(std::iter::repeat_n(
+                        variadic.sanitiser,
+                        (args.len() - required.len()) + 1,
+                    ))
                     .collect(),
             })
             // TODO: give varargs the whole arg instead of `strarg`
@@ -181,7 +193,10 @@ impl Command {
             Arguments::Exactly { required, optional } => {
                 required.iter().chain(optional.iter()).collect::<Vec<_>>()
             }
-            Arguments::VarArgs { required, variadic } => required.iter().chain(std::iter::repeat_n(variadic, vararg_count)).collect(),
+            Arguments::VarArgs { required, variadic } => required
+                .iter()
+                .chain(std::iter::repeat_n(variadic, vararg_count))
+                .collect(),
         }
     }
 
@@ -193,11 +208,10 @@ impl Command {
     }
 
     pub(crate) fn exec(&self, helper: &mut MyHelper, args: &[String]) -> CommandResult<String> {
-        let required = self.required_args();
-        if args.len() < required.len() {
+        if args.len() < self.required_args().len() {
             Err(CommandError::WithTip {
                 error: Box::new(CommandError::MissingArguments {
-                    args: required
+                    args: self.required_args()
                         .iter()
                         .map(Argument::name)
                         .map(str::to_owned)
@@ -207,10 +221,13 @@ impl Command {
                 tip: format!("try `{} {}`", "help".bold(), self.name().bold()),
             })
         } else {
+            // TODO this is not great, it assumes that the last argument is a subcommand
+            // and will forward all the arguments to them
+
             (self._internal_exec)(
                 self,
                 helper,
-                self.args_from_strings(args, &helper)?.as_slice(),
+                &self.sanitise_args(args, &helper)?
             )
         }
     }
@@ -273,7 +290,7 @@ impl Command {
     pub(crate) fn with_var_args(mut self, arg: Argument) -> Self {
         self.args = Arguments::VarArgs {
             required: vec![],
-            variadic: arg
+            variadic: arg,
         };
         self
     }

--- a/crates/mipsy_interactive/src/interactive/commands/print.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/print.rs
@@ -14,7 +14,7 @@ pub(crate) fn command() -> Command {
         .with_name("p")
         .with_desc("print an item - a register, value in memory, etc.")
         .with_exact_args()
-        .with_required_arg(Argument::new("item", |a| Ok(ArgumentKind::Item(a.to_owned()))))
+        .with_required_arg(Argument::new("item", |a| Ok(ArgumentKind::Item(a.to_owned())), |_, _| vec![]))
         .with_optional_arg(Argument::new("format", |a|
             match a {
                 "byte" | "half" | "word" | "xbyte" | "xhalf" | "xword" | "hex" | "char"
@@ -25,8 +25,9 @@ pub(crate) fn command() -> Command {
                         instead: other.to_string(),
                     })
                 }
-            }))
-
+            }, |_, _|
+                vec!["byte", "half", "word", "xbyte", "xhalf", "xword", "hex", "char"
+               , "string", "b", "h", "w", "xb", "xh", "xw", "x", "c", "s"].into_iter().map(str::to_owned).collect()))
         .with_exec(
         |_, state, label, args| {
             if label == "__help__" {

--- a/crates/mipsy_interactive/src/interactive/commands/print.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/print.rs
@@ -8,14 +8,26 @@ use mipsy_lib::{Binary, Register};
 use mipsy_parser::*;
 
 #[allow(clippy::format_in_format_args)]
-pub(crate) fn print_command() -> Command {
-    command(
-        "print",
-        vec!["p"],
-        vec!["item"],
-        vec!["format"],
-        vec![],
-        "print an item - a register, value in memory, etc.",
+pub(crate) fn command() -> Command {
+    Command::new()
+        .with_name("print")
+        .with_name("p")
+        .with_desc("print an item - a register, value in memory, etc.")
+        .with_exact_args()
+        .with_required_arg(Argument::new("item", |a| Ok(ArgumentKind::Item(a.to_owned()))))
+        .with_optional_arg(Argument::new("format", |a|
+            match a {
+                "byte" | "half" | "word" | "xbyte" | "xhalf" | "xword" | "hex" | "char"
+                | "string" | "b" | "h" | "w" | "xb" | "xh" | "xw" | "x" | "c" | "s" => Ok(ArgumentKind::Any(a.to_owned())),
+                other => {
+                    Err(CommandError::BadArgument {
+                        arg: "[format]".magenta().to_string(),
+                        instead: other.to_string(),
+                    })
+                }
+            }))
+
+        .with_exec(
         |_, state, label, args| {
             if label == "__help__" {
                 return Ok(
@@ -63,20 +75,14 @@ pub(crate) fn print_command() -> Command {
                 tip: format!("try `{}`", "help print".bold()),
             };
 
-            let arg = mipsy_parser::parse_argument(&args[0], state.config.tab_size)
+            let arg = mipsy_parser::parse_argument(if let ArgumentKind::Item(arg) = &args[0] { arg} else { unreachable!()}, state.config.tab_size)
                 .map_err(|_| get_error())?;
 
-            let print_type = &*args.get(1).cloned().unwrap_or_else(|| "word".to_string());
-            match print_type {
-                "byte" | "half" | "word" | "xbyte" | "xhalf" | "xword" | "hex" | "char"
-                | "string" | "b" | "h" | "w" | "xb" | "xh" | "xw" | "x" | "c" | "s" => {}
-                other => {
-                    return Err(CommandError::BadArgument {
-                        arg: "[format]".magenta().to_string(),
-                        instead: other.to_string(),
-                    });
-                }
-            }
+            let print_type = match args.get(1) {
+                Some(ArgumentKind::Any(t)) => t.as_str(),
+                None => "word",
+                _ => unreachable!()
+            };
 
             let empty_binary = Binary::default();
             let binary = state.binary.as_ref().unwrap_or(&empty_binary);

--- a/crates/mipsy_interactive/src/interactive/commands/print.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/print.rs
@@ -16,13 +16,13 @@ pub(crate) fn command() -> Command {
         .with_exact_args()
         .with_required_arg(Argument::new(
             "item",
-            |_, a, _| Ok(ArgumentKind::String(a.to_owned())),
+            |a, _| Ok(ArgumentKind::String(a.to_owned())),
             // TODO: maybe register and label hinting idk
-            |_, _, _| vec![],
+            |_, _| vec![],
         ))
         .with_optional_arg(Argument::new(
             "format",
-            |_, a, _| match a {
+            |a, _| match a {
                 "byte" | "half" | "word" | "xbyte" | "xhalf" | "xword" | "hex" | "char"
                 | "string" | "b" | "h" | "w" | "xb" | "xh" | "xw" | "x" | "c" | "s" => {
                     Ok(ArgumentKind::String(a.to_owned()))
@@ -32,7 +32,7 @@ pub(crate) fn command() -> Command {
                     instead: other.to_string(),
                 }),
             },
-            |_, _, _| {
+            |_, _| {
                 vec![
                     "byte", "half", "word", "xbyte", "xhalf", "xword", "hex", "char", "string",
                 ]
@@ -78,13 +78,13 @@ pub(crate) fn command() -> Command {
             let get_error = || CommandError::WithTip {
                 error: Box::new(CommandError::BadArgument {
                     arg: "<item>".magenta().to_string(),
-                    instead: args[0].to_owned().into(),
+                    instead: args[0].to_owned().try_into().unwrap(),
                 }),
                 tip: format!("try `{}`", "help print".bold()),
             };
 
             let arg = mipsy_parser::parse_argument(
-                String::from(args[0].to_owned()),
+                String::try_from(args[0].to_owned()).unwrap(),
                 helper.state.config.tab_size,
             )
             .map_err(|_| get_error())?;
@@ -324,7 +324,11 @@ pub(crate) fn command() -> Command {
                         _ => unreachable!(),
                     };
 
-                    prompt::success_nl(format!("{} = {}", String::from(args[0].to_owned()), value));
+                    prompt::success_nl(format!(
+                        "{} = {}",
+                        String::try_from(args[0].to_owned()).unwrap(),
+                        value
+                    ));
                 }
                 _ => return Err(get_error()),
             }

--- a/crates/mipsy_interactive/src/interactive/commands/print.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/print.rs
@@ -17,6 +17,7 @@ pub(crate) fn command() -> Command {
         .with_required_arg(Argument::new(
             "item",
             |_, a, _| Ok(ArgumentKind::String(a.to_owned())),
+            // TODO: maybe register and label hinting idk
             |_, _, _| vec![],
         ))
         .with_optional_arg(Argument::new(
@@ -34,7 +35,6 @@ pub(crate) fn command() -> Command {
             |_, _, _| {
                 vec![
                     "byte", "half", "word", "xbyte", "xhalf", "xword", "hex", "char", "string",
-                    "b", "h", "w", "xb", "xh", "xw", "x", "c", "s",
                 ]
                 .into_iter()
                 .map(str::to_owned)

--- a/crates/mipsy_interactive/src/interactive/commands/print.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/print.rs
@@ -16,12 +16,12 @@ pub(crate) fn command() -> Command {
         .with_exact_args()
         .with_required_arg(Argument::new(
             "item",
-            |a, _| Ok(ArgumentKind::String(a.to_owned())),
-            |_, _| vec![],
+            |_, a, _| Ok(ArgumentKind::String(a.to_owned())),
+            |_, _, _| vec![],
         ))
         .with_optional_arg(Argument::new(
             "format",
-            |a, _| match a {
+            |_, a, _| match a {
                 "byte" | "half" | "word" | "xbyte" | "xhalf" | "xword" | "hex" | "char"
                 | "string" | "b" | "h" | "w" | "xb" | "xh" | "xw" | "x" | "c" | "s" => {
                     Ok(ArgumentKind::String(a.to_owned()))
@@ -31,7 +31,7 @@ pub(crate) fn command() -> Command {
                     instead: other.to_string(),
                 }),
             },
-            |_, _| {
+            |_, _, _| {
                 vec![
                     "byte", "half", "word", "xbyte", "xhalf", "xword", "hex", "char", "string",
                     "b", "h", "w", "xb", "xh", "xw", "x", "c", "s",

--- a/crates/mipsy_interactive/src/interactive/commands/print.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/print.rs
@@ -4,7 +4,7 @@ use crate::interactive::{error::CommandError, prompt};
 
 use super::*;
 use colored::*;
-use mipsy_lib::{Binary, Register};
+use mipsy_lib::Register;
 use mipsy_parser::*;
 
 #[allow(clippy::format_in_format_args)]
@@ -74,7 +74,7 @@ pub(crate) fn command() -> Command {
             format!("{}{}", "c".yellow().bold(), "har".bold()),
             format!("{}{}", "s".yellow().bold(), "tring".bold()),
         ))
-        .with_exec(|_, state, _, args| {
+        .with_exec(|_, helper, args| {
             let get_error = || CommandError::WithTip {
                 error: Box::new(CommandError::BadArgument {
                     arg: "<item>".magenta().to_string(),
@@ -85,7 +85,7 @@ pub(crate) fn command() -> Command {
 
             let arg = mipsy_parser::parse_argument(
                 String::from(args[0].to_owned()),
-                state.config.tab_size,
+                helper.state.config.tab_size,
             )
             .map_err(|_| get_error())?;
 
@@ -95,9 +95,12 @@ pub(crate) fn command() -> Command {
                 _ => unreachable!(),
             };
 
-            let empty_binary = Binary::default();
-            let binary = state.binary.as_ref().unwrap_or(&empty_binary);
-            let runtime = &state.runtime;
+            let binary = helper
+                .state
+                .binary
+                .as_ref()
+                .ok_or(CommandError::MustLoadFile)?;
+            let runtime = &helper.state.runtime;
 
             match arg {
                 MpArgument::Register(MpRegister::Normal(ident)) => {

--- a/crates/mipsy_interactive/src/interactive/commands/print.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/print.rs
@@ -14,11 +14,11 @@ pub(crate) fn command() -> Command {
         .with_name("p")
         .with_desc("print an item - a register, value in memory, etc.")
         .with_exact_args()
-        .with_required_arg(Argument::new("item", |a| Ok(ArgumentKind::Item(a.to_owned())), |_, _| vec![]))
-        .with_optional_arg(Argument::new("format", |a|
+        .with_required_arg(Argument::new("item", |a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _| vec![]))
+        .with_optional_arg(Argument::new("format", |a, _|
             match a {
                 "byte" | "half" | "word" | "xbyte" | "xhalf" | "xword" | "hex" | "char"
-                | "string" | "b" | "h" | "w" | "xb" | "xh" | "xw" | "x" | "c" | "s" => Ok(ArgumentKind::Any(a.to_owned())),
+                | "string" | "b" | "h" | "w" | "xb" | "xh" | "xw" | "x" | "c" | "s" => Ok(ArgumentKind::String(a.to_owned())),
                 other => {
                     Err(CommandError::BadArgument {
                         arg: "[format]".magenta().to_string(),
@@ -29,7 +29,7 @@ pub(crate) fn command() -> Command {
                 vec!["byte", "half", "word", "xbyte", "xhalf", "xword", "hex", "char"
                , "string", "b", "h", "w", "xb", "xh", "xw", "x", "c", "s"].into_iter().map(str::to_owned).collect()))
         .with_exec(
-        |_, state, label, args| {
+        |_, state, _, label, args| {
             if label == "__help__" {
                 return Ok(
                     format!(
@@ -71,16 +71,16 @@ pub(crate) fn command() -> Command {
             let get_error = || CommandError::WithTip {
                 error: Box::new(CommandError::BadArgument {
                     arg: "<item>".magenta().to_string(),
-                    instead: args[0].to_string(),
+                    instead: args[0].to_owned().into()
                 }),
                 tip: format!("try `{}`", "help print".bold()),
             };
 
-            let arg = mipsy_parser::parse_argument(if let ArgumentKind::Item(arg) = &args[0] { arg} else { unreachable!()}, state.config.tab_size)
+            let arg = mipsy_parser::parse_argument(String::from(args[0].to_owned()), state.config.tab_size)
                 .map_err(|_| get_error())?;
 
             let print_type = match args.get(1) {
-                Some(ArgumentKind::Any(t)) => t.as_str(),
+                Some(ArgumentKind::String(t)) => t,
                 None => "word",
                 _ => unreachable!()
             };
@@ -311,7 +311,7 @@ pub(crate) fn command() -> Command {
                         _ => unreachable!(),
                     };
 
-                    prompt::success_nl(format!("{} = {}", args[0], value));
+                    prompt::success_nl(format!("{} = {}", String::from(args[0].to_owned()), value));
                 }
                 _ => return Err(get_error()),
             }

--- a/crates/mipsy_interactive/src/interactive/commands/print.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/print.rs
@@ -14,75 +14,85 @@ pub(crate) fn command() -> Command {
         .with_name("p")
         .with_desc("print an item - a register, value in memory, etc.")
         .with_exact_args()
-        .with_required_arg(Argument::new("item", |a, _| Ok(ArgumentKind::String(a.to_owned())), |_, _| vec![]))
-        .with_optional_arg(Argument::new("format", |a, _|
-            match a {
+        .with_required_arg(Argument::new(
+            "item",
+            |a, _| Ok(ArgumentKind::String(a.to_owned())),
+            |_, _| vec![],
+        ))
+        .with_optional_arg(Argument::new(
+            "format",
+            |a, _| match a {
                 "byte" | "half" | "word" | "xbyte" | "xhalf" | "xword" | "hex" | "char"
-                | "string" | "b" | "h" | "w" | "xb" | "xh" | "xw" | "x" | "c" | "s" => Ok(ArgumentKind::String(a.to_owned())),
-                other => {
-                    Err(CommandError::BadArgument {
-                        arg: "[format]".magenta().to_string(),
-                        instead: other.to_string(),
-                    })
+                | "string" | "b" | "h" | "w" | "xb" | "xh" | "xw" | "x" | "c" | "s" => {
+                    Ok(ArgumentKind::String(a.to_owned()))
                 }
-            }, |_, _|
-                vec!["byte", "half", "word", "xbyte", "xhalf", "xword", "hex", "char"
-               , "string", "b", "h", "w", "xb", "xh", "xw", "x", "c", "s"].into_iter().map(str::to_owned).collect()))
-        .with_exec(
-        |_, state, _, label, args| {
-            if label == "__help__" {
-                return Ok(
-                    format!(
-                        "Prints the current value of an {0} in the loaded program.\n\
-                         {0} can be one of:\n\
-                    \x20- a {1}: named (`{2}{3}`) or numbered (`{2}{4}`),\n\
-                    \x20- a {5} {1}: `{2}{6}`, `{2}{7}`, `{2}{8}`,\n\
-                    \x20- an {9}: decimal (`4194304`), hex (`{10}400000`), labelled (`{11}`),\n\
-                    \x20- {12}: `{2}{13}` - prints all currently initialised registers.\n\
-                         {14} can optionally be specified (default: `{15}`) to specify how the value\n\
-                    \x20 should be printed. Options: `{16}`, `{17}`, `{15}`, `{18}{16}`, `{18}{17}`,\n\
-                    \x20                             `{18}{15}` / `{19}{18}`, `{20}`, `{21}`.",
-                        "<item>".magenta(),
-                        "register".yellow().bold(),
-                        "$".yellow(),
-                        "t3".bold(),
-                        "12".bold(),
-                        "special".yellow().bold(),
-                        "pc".bold(),
-                        "hi".bold(),
-                        "lo".bold(),
-                        "address".yellow().bold(),
-                        "0x".yellow(),
-                        "my_label".yellow().bold(),
-                        "all registers".yellow().bold(),
-                        "all".bold(),
-                        "[format]".magenta(),
-                        format!("{}{}", "w".yellow().bold(), "ord".bold()),
-                        format!("{}{}", "b".yellow().bold(), "yte".bold()),
-                        format!("{}{}", "h".yellow().bold(), "alf".bold()),
-                        "x".yellow().bold(),
-                        "he".bold(),
-                        format!("{}{}", "c".yellow().bold(), "har".bold()),
-                        format!("{}{}", "s".yellow().bold(), "tring".bold()),
-                    ),
-                );
-            }
-
+                other => Err(CommandError::BadArgument {
+                    arg: "[format]".magenta().to_string(),
+                    instead: other.to_string(),
+                }),
+            },
+            |_, _| {
+                vec![
+                    "byte", "half", "word", "xbyte", "xhalf", "xword", "hex", "char", "string",
+                    "b", "h", "w", "xb", "xh", "xw", "x", "c", "s",
+                ]
+                .into_iter()
+                .map(str::to_owned)
+                .collect()
+            },
+        ))
+        .with_help(format!(
+            "Prints the current value of an {0} in the loaded program.\n\
+                {0} can be one of:\n\
+                \x20- a {1}: named (`{2}{3}`) or numbered (`{2}{4}`),\n\
+                \x20- a {5} {1}: `{2}{6}`, `{2}{7}`, `{2}{8}`,\n\
+                \x20- an {9}: decimal (`4194304`), hex (`{10}400000`), labelled (`{11}`),\n\
+                \x20- {12}: `{2}{13}` - prints all currently initialised registers.\n\
+                {14} can optionally be specified (default: `{15}`) to specify how the value\n\
+                \x20 should be printed. Options: `{16}`, `{17}`, `{15}`, `{18}{16}`, `{18}{17}`,\n\
+                \x20                             `{18}{15}` / `{19}{18}`, `{20}`, `{21}`.",
+            "<item>".magenta(),
+            "register".yellow().bold(),
+            "$".yellow(),
+            "t3".bold(),
+            "12".bold(),
+            "special".yellow().bold(),
+            "pc".bold(),
+            "hi".bold(),
+            "lo".bold(),
+            "address".yellow().bold(),
+            "0x".yellow(),
+            "my_label".yellow().bold(),
+            "all registers".yellow().bold(),
+            "all".bold(),
+            "[format]".magenta(),
+            format!("{}{}", "w".yellow().bold(), "ord".bold()),
+            format!("{}{}", "b".yellow().bold(), "yte".bold()),
+            format!("{}{}", "h".yellow().bold(), "alf".bold()),
+            "x".yellow().bold(),
+            "he".bold(),
+            format!("{}{}", "c".yellow().bold(), "har".bold()),
+            format!("{}{}", "s".yellow().bold(), "tring".bold()),
+        ))
+        .with_exec(|_, state, _, args| {
             let get_error = || CommandError::WithTip {
                 error: Box::new(CommandError::BadArgument {
                     arg: "<item>".magenta().to_string(),
-                    instead: args[0].to_owned().into()
+                    instead: args[0].to_owned().into(),
                 }),
                 tip: format!("try `{}`", "help print".bold()),
             };
 
-            let arg = mipsy_parser::parse_argument(String::from(args[0].to_owned()), state.config.tab_size)
-                .map_err(|_| get_error())?;
+            let arg = mipsy_parser::parse_argument(
+                String::from(args[0].to_owned()),
+                state.config.tab_size,
+            )
+            .map_err(|_| get_error())?;
 
             let print_type = match args.get(1) {
                 Some(ArgumentKind::String(t)) => t,
                 None => "word",
-                _ => unreachable!()
+                _ => unreachable!(),
             };
 
             let empty_binary = Binary::default();
@@ -317,8 +327,7 @@ pub(crate) fn command() -> Command {
             }
 
             Ok("".into())
-        },
-    )
+        })
 }
 
 fn format_simple_print(val: i32, print_type: &str) -> String {

--- a/crates/mipsy_interactive/src/interactive/commands/reset.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/reset.rs
@@ -8,7 +8,7 @@ pub(crate) fn command() -> Command {
         .with_name("reset")
         .with_name("re")
         .with_desc("reset the currently loaded program to its initial state")
-        .with_exec(|_, state, label, _| {
+        .with_exec(|_, state, _, label, _| {
             if label == "__help__" {
                 return Ok(format!(
                     "Resets the currently loaded program to its inital state. This is\n\

--- a/crates/mipsy_interactive/src/interactive/commands/reset.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/reset.rs
@@ -8,19 +8,16 @@ pub(crate) fn command() -> Command {
         .with_name("reset")
         .with_name("re")
         .with_desc("reset the currently loaded program to its initial state")
-        .with_exec(|_, state, _, label, _| {
-            if label == "__help__" {
-                return Ok(format!(
-                    "Resets the currently loaded program to its inital state. This is\n\
+        .with_help(format!(
+            "Resets the currently loaded program to its inital state. This is\n\
                      \x20 effectively the same as using `{} {}` using the same file again.\n\
                          It is often used after `{}` or `{}` have reached the end of the program.",
-                    "load".bold(),
-                    "<file>".magenta(),
-                    "run".bold(),
-                    "step".bold(),
-                ));
-            }
-
+            "load".bold(),
+            "<file>".magenta(),
+            "run".bold(),
+            "step".bold(),
+        ))
+        .with_exec(|_, state, _, _| {
             state.reset()?;
             prompt::success_nl("program reset");
 

--- a/crates/mipsy_interactive/src/interactive/commands/reset.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/reset.rs
@@ -17,8 +17,8 @@ pub(crate) fn command() -> Command {
             "run".bold(),
             "step".bold(),
         ))
-        .with_exec(|_, state, _, _| {
-            state.reset()?;
+        .with_exec(|_, helper, _| {
+            helper.state.reset()?;
             prompt::success_nl("program reset");
 
             Ok("".into())

--- a/crates/mipsy_interactive/src/interactive/commands/reset.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/reset.rs
@@ -8,7 +8,7 @@ pub(crate) fn command() -> Command {
         .with_name("reset")
         .with_name("re")
         .with_desc("reset the currently loaded program to its initial state")
-        .with_exec(|_, state, label, _args| {
+        .with_exec(|_, state, label, _| {
             if label == "__help__" {
                 return Ok(format!(
                     "Resets the currently loaded program to its inital state. This is\n\

--- a/crates/mipsy_interactive/src/interactive/commands/reset.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/reset.rs
@@ -3,15 +3,12 @@ use crate::interactive::prompt;
 use super::*;
 use colored::*;
 
-pub(crate) fn reset_command() -> Command {
-    command(
-        "reset",
-        vec!["re"],
-        vec![],
-        vec![],
-        vec![],
-        "reset the currently loaded program to its initial state",
-        |_, state, label, _args| {
+pub(crate) fn command() -> Command {
+    Command::new()
+        .with_name("reset")
+        .with_name("re")
+        .with_desc("reset the currently loaded program to its initial state")
+        .with_exec(|_, state, label, _args| {
             if label == "__help__" {
                 return Ok(format!(
                     "Resets the currently loaded program to its inital state. This is\n\
@@ -28,6 +25,5 @@ pub(crate) fn reset_command() -> Command {
             prompt::success_nl("program reset");
 
             Ok("".into())
-        },
-    )
+        })
 }

--- a/crates/mipsy_interactive/src/interactive/commands/run.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/run.rs
@@ -3,14 +3,12 @@ use crate::interactive::error::CommandError;
 use super::*;
 use colored::*;
 
-pub(crate) fn run_command() -> Command {
-    command(
-        "run",
-        vec!["r"],
-        vec![],
-        vec![],
-        vec![],
-        "run the currently loaded program until it finishes",
+pub(crate) fn command() -> Command {
+    Command::new()
+        .with_name("run")
+        .with_name("r")
+        .with_desc("run the currently loaded program until it finishes")
+        .with_exec(
         |_, state, label, _args| {
             if label == "__help__" {
                 return Ok(

--- a/crates/mipsy_interactive/src/interactive/commands/run.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/run.rs
@@ -9,7 +9,7 @@ pub(crate) fn command() -> Command {
         .with_name("r")
         .with_desc("run the currently loaded program until it finishes")
         .with_exec(
-        |_, state, label, _| {
+        |_, state, helper, label, _| {
             if label == "__help__" {
                 return Ok(
                     format!(
@@ -28,7 +28,7 @@ pub(crate) fn command() -> Command {
                 return Err(CommandError::MustLoadFile);
             }
 
-            state.run()
+            state.run(helper)
         },
     )
 }

--- a/crates/mipsy_interactive/src/interactive/commands/run.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/run.rs
@@ -9,7 +9,7 @@ pub(crate) fn command() -> Command {
         .with_name("r")
         .with_desc("run the currently loaded program until it finishes")
         .with_exec(
-        |_, state, label, _args| {
+        |_, state, label, _| {
             if label == "__help__" {
                 return Ok(
                     format!(

--- a/crates/mipsy_interactive/src/interactive/commands/run.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/run.rs
@@ -8,10 +8,7 @@ pub(crate) fn command() -> Command {
         .with_name("run")
         .with_name("r")
         .with_desc("run the currently loaded program until it finishes")
-        .with_exec(
-        |_, state, helper, label, _| {
-            if label == "__help__" {
-                return Ok(
+        .with_help(
                     format!(
                         "Runs the currently loaded program. It will run from wherever execution\n\
                      \x20 is currently (i.e. if you have used `{0}`, it will start from where you\n\
@@ -21,9 +18,9 @@ pub(crate) fn command() -> Command {
                         "step".bold(),
                         "not".red().bold(),
                     ),
-                );
-            }
-
+        )
+        .with_exec(
+        |_, state, helper, _| {
             if state.binary.is_none() {
                 return Err(CommandError::MustLoadFile);
             }

--- a/crates/mipsy_interactive/src/interactive/commands/run.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/run.rs
@@ -8,24 +8,20 @@ pub(crate) fn command() -> Command {
         .with_name("run")
         .with_name("r")
         .with_desc("run the currently loaded program until it finishes")
-        .with_help(
-                    format!(
-                        "Runs the currently loaded program. It will run from wherever execution\n\
-                     \x20 is currently (i.e. if you have used `{0}`, it will start from where you\n\
-                     \x20 have currently stepped to).\n\
-                         This will run in \"execution\" mode, {1} printing out instruction information,\n\
-                     \x20 or other debug information that you would see while using `{0}`.",
-                        "step".bold(),
-                        "not".red().bold(),
-                    ),
-        )
-        .with_exec(
-        |_, state, helper, _| {
+        .with_help(format!(
+            "Runs the currently loaded program. It will run from wherever execution\n\
+                \x20 is currently (i.e. if you have used `{0}`, it will start from where you\n\
+                    \x20 have currently stepped to).\n\
+                This will run in \"execution\" mode, {1} printing out instruction information,\n\
+                \x20 or other debug information that you would see while using `{0}`.",
+            "step".bold(),
+            "not".red().bold(),
+        ))
+        .with_exec(|_, state, helper, _| {
             if state.binary.is_none() {
                 return Err(CommandError::MustLoadFile);
             }
 
             state.run(helper)
-        },
-    )
+        })
 }

--- a/crates/mipsy_interactive/src/interactive/commands/run.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/run.rs
@@ -17,11 +17,11 @@ pub(crate) fn command() -> Command {
             "step".bold(),
             "not".red().bold(),
         ))
-        .with_exec(|_, state, helper, _| {
-            if state.binary.is_none() {
+        .with_exec(|_, helper, _| {
+            if helper.state.binary.is_none() {
                 return Err(CommandError::MustLoadFile);
             }
 
-            state.run(helper)
+            State::run(helper)
         })
 }

--- a/crates/mipsy_interactive/src/interactive/commands/step.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/step.rs
@@ -12,64 +12,31 @@ pub(super) fn args_numbers(args: &[ArgumentKind]) -> Vec<i64> {
     args.iter().cloned().map(i64::from).collect()
 }
 
-fn subcmd_help() -> String {
-    get_step_help_text(
-        format!(
-            "\
-                Available {1}s are:\n\
-                \n\
-                {0} {2}     : syscalls 5, 6, 7, 8, 12\n\
-                {0} {3}    : syscalls 1, 2, 3, 4, 11\n\
-                {0} {4}   : syscalls 1, 5\n\
-                {0} {5}     : syscalls 2, 6\n\
-                {0} {6}    : syscalls 3, 7\n\
-                {0} {7}    : syscalls 4, 8\n\
-                {0} {8} : syscalls 11, 12\n\
-                {0} {9}      : syscalls 13, 14, 15, 16\n\
-                \n\
-                {10} {11} will provide more information about the specified subcommand.\n\
-                \n\
-                By default, this steps forwards until your program's next syscall, or finishes.",
-            "step syscall".bold().yellow(),
-            "[type]".magenta(),
-            "input".purple(),
-            "output".purple(),
-            "integer".purple(),
-            "float".purple(),
-            "double".purple(),
-            "string".purple(),
-            "character".purple(),
-            "file".purple(),
-            "help step syscall".white().bold(),
-            "[type]".magenta().bold(),
-        )
-        .as_ref(),
-    )
-}
-
 fn call_subcmds(
     cmd: &Command,
     state: &mut State,
     helper: &MyHelper,
     args: &[ArgumentKind],
 ) -> CommandResult<String> {
-    match args.get(0) {
-        Some(ArgumentKind::String(arg)) => {
-            if let Some(cmd) = cmd.subcommands.iter().find(|c| c.names.contains(arg)) {
-                return (cmd._internal_exec)(cmd, state, helper, &args[1..]);
-            }
+    if let Some(arg) = args.get(0) {
+        if let Some(cmd) = cmd
+            .subcommands
+            .iter()
+            .find(|c| c.names.contains(&arg.clone().into()))
+        {
+            return (cmd._internal_exec)(cmd, state, helper, &args[1..]);
         }
-        None | Some(ArgumentKind::Number(_)) => {}
     }
 
     step_syscall(state, helper)
 }
 
-fn subcmd() -> Command {
-    Command::new()
+pub(crate) fn command() -> Command {
+    let subcmd = Command::new()
         .with_name("syscall")
         .with_name("s")
         .with_name("sys")
+        .with_help(subcmd_help())
         .with_subcommand(
             Command::new()
                 .with_name("input")
@@ -145,25 +112,22 @@ fn subcmd() -> Command {
                 ))
                 .with_exec(|_, state, helper, _| step_file(state, helper)),
         )
-        .with_help(subcmd_help())
-        .with_exec(call_subcmds)
-}
+        .with_required_arg(Argument::subcommands())
+        .with_exec(call_subcmds);
 
-pub(crate) fn command() -> Command {
     let times_arg = Argument::new(
         "times",
-        |a, _| match a.parse::<i32>() {
+        |_, a, _| match a.parse::<i32>() {
             Ok(i) => Ok(ArgumentKind::Number(i as _)),
             Err(_) => Err(CommandError::WithTip {
                 error: Box::new(CommandError::ArgExpectedI32 {
                     arg: "[times]".bright_magenta().to_string(),
                     instead: a.to_owned(),
                 }),
-                // tip: format!("try `{} {}`", "help".bold(), label.bold()),
-                tip: format!("try TODOTODOIJJDSKJAKDJTODOOOOOOOOOOOOOTODOOOOOOOOOOOO"),
+                tip: format!("try `{} {}`", "help".bold(), "step".bold()),
             }),
         },
-        |_, _| vec![],
+        |_, _, _| vec![],
     );
 
     Command::new()
@@ -188,8 +152,8 @@ pub(crate) fn command() -> Command {
                 ))
                 .with_exec(|_, state, helper, args| step_back(state, &args_numbers(args), helper)),
         )
-        .with_subcommand(subcmd())
-        .with_help(subcmd_help())
+        .with_subcommand(subcmd)
+        .with_help(get_long_help())
         .with_exec(call_subcmds)
 }
 
@@ -448,5 +412,40 @@ fn get_step_help_text(unique_text: &str) -> String {
          To step backwards (i.e. back in time), use `{}`.",
         unique_text,
         "step back".bold(),
+    )
+}
+
+fn subcmd_help() -> String {
+    get_step_help_text(
+        format!(
+            "\
+                Available {1}s are:\n\
+                \n\
+                {0} {2}\t\t: syscalls 5, 6, 7, 8, 12\n\
+                {0} {3}\t\t: syscalls 1, 2, 3, 4, 11\n\
+                {0} {4}\t\t: syscalls 1, 5\n\
+                {0} {5}\t\t: syscalls 2, 6\n\
+                {0} {6}\t\t: syscalls 3, 7\n\
+                {0} {7}\t\t: syscalls 4, 8\n\
+                {0} {8}\t\t: syscalls 11, 12\n\
+                {0} {9}\t\t: syscalls 13, 14, 15, 16\n\
+                \n\
+                {10} {11} will provide more information about the specified subcommand.\n\
+                \n\
+                By default, this steps forwards until your program's next syscall, or finishes.",
+            "step syscall".bold().yellow(),
+            "[type]".magenta(),
+            "input".purple(),
+            "output".purple(),
+            "integer".purple(),
+            "float".purple(),
+            "double".purple(),
+            "string".purple(),
+            "character".purple(),
+            "file".purple(),
+            "help step syscall".white().bold(),
+            "[type]".magenta().bold(),
+        )
+        .as_ref(),
     )
 }

--- a/crates/mipsy_interactive/src/interactive/commands/step.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/step.rs
@@ -1,5 +1,4 @@
 use std::sync::atomic::Ordering;
-use std::vec;
 
 use crate::interactive::error::CommandError;
 use crate::prompt;
@@ -9,138 +8,107 @@ use super::*;
 use colored::*;
 use mipsy_lib::Register;
 
-pub(crate) fn step_command() -> Command {
-    let subcommands = vec![
-        command(
-            "back",
-            vec!["b"],
-            vec![],
-            vec!["times"],
-            vec![],
-            "",
-            |_, state, label, args| step_back(state, label, args),
-        ),
-        command(
-            "syscall",
-            vec!["s", "sys"],
-            vec![],
-            vec![],
-            vec![
-                command(
-                    "input",
-                    vec!["in"],
-                    vec![],
-                    vec![],
-                    vec![],
-                    "",
-                    |_, state, label, args| step_input(state, label, args),
-                ),
-                command(
-                    "output",
-                    vec!["out"],
-                    vec![],
-                    vec![],
-                    vec![],
-                    "",
-                    |_, state, label, args| step_output(state, label, args),
-                ),
-                command(
-                    "integer",
-                    vec!["int"],
-                    vec![],
-                    vec![],
-                    vec![],
-                    "",
-                    |_, state, label, args| step_integer(state, label, args),
-                ),
-                command(
-                    "float",
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    "",
-                    |_, state, label, args| step_float(state, label, args),
-                ),
-                command(
-                    "double",
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    "",
-                    |_, state, label, args| step_double(state, label, args),
-                ),
-                command(
-                    "string",
-                    vec!["str"],
-                    vec![],
-                    vec![],
-                    vec![],
-                    "",
-                    |_, state, label, args| step_string(state, label, args),
-                ),
-                command(
-                    "character",
-                    vec!["char"],
-                    vec![],
-                    vec![],
-                    vec![],
-                    "",
-                    |_, state, label, args| step_character(state, label, args),
-                ),
-                command(
-                    "file",
-                    vec![],
-                    vec![],
-                    vec![],
-                    vec![],
-                    "",
-                    |_, state, label, args| step_file(state, label, args),
-                ),
-            ],
-            "",
-            |cmd, state, label, args| {
-                let cmd = args.get(0).and_then(|arg| {
-                    cmd.subcommands
-                        .iter()
-                        .find(|c| &c.name == arg || c.aliases.contains(arg))
-                });
-                match cmd {
-                    Some(cmd) => cmd.exec(state, label, &args[1..]),
-                    None => step_syscall(state, label, args),
-                }
-            },
-        ),
-    ];
-
-    command(
-        "step",
-        vec!["s", "back"],
-        vec![],
-        vec!["times", "subcommand"],
-        subcommands,
-        "step forwards or execute a subcommand",
-        |cmd, state, label, args| {
-            if label == "__help__" && args.is_empty() {
-                return Ok(get_long_help());
+fn call_subcmds(
+    cmd: &Command,
+    state: &mut State,
+    label: &str,
+    args: &[ArgumentKind],
+) -> CommandResult<String> {
+    match args.get(0) {
+        Some(ArgumentKind::SubCommand(arg)) => {
+            if let Some(cmd) = cmd.subcommands.iter().find(|c| c.names.contains(arg)) {
+                return (cmd._internal_exec)(cmd, state, label, &args[1..]);
             }
+        }
+        None | Some(ArgumentKind::Number(_)) => {}
+        _ => unreachable!(),
+    }
 
-            if label == "back" {
-                return step_back(state, label, args);
-            }
+    step_syscall(state, label)
+}
 
-            let cmd = args.get(0).and_then(|arg| {
-                cmd.subcommands
-                    .iter()
-                    .find(|c| &c.name == arg || c.aliases.contains(arg))
-            });
-            match cmd {
-                Some(cmd) => cmd.exec(state, label, &args[1..]),
-                None => step_forward(state, label, args),
-            }
-        },
-    )
+pub(crate) fn command() -> Command {
+    let subcmd = Command::new()
+        .with_name("syscall")
+        .with_name("s")
+        .with_name("sys")
+        .with_subcommand(
+            Command::new()
+                .with_name("input")
+                .with_name("in")
+                .with_exec(|_, state, label, _| step_input(state, label)),
+        )
+        .with_subcommand(
+            Command::new()
+                .with_name("output")
+                .with_name("out")
+                .with_exec(|_, state, label, _| step_output(state, label)),
+        )
+        .with_subcommand(
+            Command::new()
+                .with_name("integer")
+                .with_name("int")
+                .with_exec(|_, state, label, _| step_integer(state, label)),
+        )
+        .with_subcommand(
+            Command::new()
+                .with_name("float")
+                .with_exec(|_, state, label, _| step_float(state, label)),
+        )
+        .with_subcommand(
+            Command::new()
+                .with_name("double")
+                .with_exec(|_, state, label, _| step_double(state, label)),
+        )
+        .with_subcommand(
+            Command::new()
+                .with_name("string")
+                .with_name("str")
+                .with_exec(|_, state, label, _| step_string(state, label)),
+        )
+        .with_subcommand(
+            Command::new()
+                .with_name("character")
+                .with_name("char")
+                .with_exec(|_, state, label, _| step_character(state, label)),
+        )
+        .with_subcommand(
+            Command::new()
+                .with_name("file")
+                .with_exec(|_, state, label, _| step_file(state, label)),
+        )
+        .with_exec(call_subcmds);
+
+    let times_arg = Argument::new("times", |a| match a.parse::<i32>() {
+        Ok(i) => Ok(ArgumentKind::Number(i as _)),
+        Err(_) => Err(CommandError::WithTip {
+            error: Box::new(CommandError::ArgExpectedI32 {
+                arg: "[times]".bright_magenta().to_string(),
+                instead: a.to_owned(),
+            }),
+            // tip: format!("try `{} {}`", "help".bold(), label.bold()),
+            tip: format!("try TODOTODOIJJDSKJAKDJTODOOOOOOOOOOOOOTODOOOOOOOOOOOO"),
+        }),
+    });
+
+    Command::new()
+        .with_name("step")
+        .with_desc("step forwards or execute a subcommand")
+        .with_name("s")
+        .with_name("back")
+        .with_optional_arg(times_arg.clone())
+        .with_optional_arg(Argument::new("subcommand", |a| {
+            Ok(ArgumentKind::SubCommand(a.to_owned()))
+        }))
+        .with_subcommand(
+            Command::new()
+                .with_name("back")
+                .with_name("b")
+                .with_optional_arg(times_arg)
+                .with_exec(|_, state, label, args| step_back(state, label, args)),
+        )
+        .with_subcommand(subcmd.clone())
+        .with_exec(call_subcmds)
 }
 
 fn get_long_help() -> String {
@@ -167,34 +135,30 @@ fn get_long_help() -> String {
     )
 }
 
-fn step_forward(state: &mut State, label: &str, args: &[String]) -> Result<String, CommandError> {
+fn step_forward(
+    state: &mut State,
+    label: &str,
+    args: &[ArgumentKind],
+) -> Result<String, CommandError> {
     let times = match args.first() {
-        Some(arg) => match arg.parse::<i32>() {
-            Ok(num) => {
-                if num.is_negative() {
-                    return step_back(
-                        state,
-                        label,
-                        [num.abs().to_string()]
-                            .into_iter()
-                            .chain(args.iter().skip(1).cloned())
-                            .collect::<Vec<String>>()
-                            .as_ref(),
-                    );
-                }
-
-                Ok(num)
+        Some(&ArgumentKind::Number(num)) => {
+            if num.is_negative() {
+                return step_back(
+                    state,
+                    label,
+                    [ArgumentKind::Number(num as _)]
+                        .into_iter()
+                        .chain(args.iter().skip(1).cloned())
+                        .collect::<Vec<_>>()
+                        .as_ref(),
+                );
             }
-            Err(_) => Err(CommandError::WithTip {
-                error: Box::new(CommandError::ArgExpectedI32 {
-                    arg: "[times]".bright_magenta().to_string(),
-                    instead: arg.to_owned(),
-                }),
-                tip: format!("try `{} {}`", "help".bold(), label.bold()),
-            }),
-        },
-        None => Ok(1),
-    }?;
+
+            num as _
+        }
+        None => 1,
+        _ => unreachable!(),
+    };
 
     if state.exited {
         return Err(CommandError::ProgramExited);
@@ -225,7 +189,7 @@ fn step_forward(state: &mut State, label: &str, args: &[String]) -> Result<Strin
     Ok("".into())
 }
 
-fn step_back(state: &mut State, label: &str, args: &[String]) -> Result<String, CommandError> {
+fn step_back(state: &mut State, label: &str, args: &[ArgumentKind]) -> CommandResult<String> {
     if label == "__help__" {
         return Ok(format!(
             "Steps backwards one instruction, or {0} instructions if specified.\n\
@@ -238,32 +202,24 @@ fn step_back(state: &mut State, label: &str, args: &[String]) -> Result<String, 
     }
 
     let times = match args.first() {
-        Some(arg) => match arg.parse::<i32>() {
-            Ok(num) => {
-                if num.is_negative() {
-                    return step_forward(
-                        state,
-                        label,
-                        [num.abs().to_string()]
-                            .into_iter()
-                            .chain(args.iter().skip(1).cloned())
-                            .collect::<Vec<String>>()
-                            .as_ref(),
-                    );
-                }
-
-                Ok(num)
+        Some(ArgumentKind::Number(num)) => {
+            if num.is_negative() {
+                return step_forward(
+                    state,
+                    label,
+                    [ArgumentKind::Number(num.abs())]
+                        .into_iter()
+                        .chain(args.iter().skip(1).cloned())
+                        .collect::<Vec<_>>()
+                        .as_ref(),
+                );
             }
-            Err(_) => Err(CommandError::WithTip {
-                error: Box::new(CommandError::ArgExpectedI32 {
-                    arg: "[times]".bright_magenta().to_string(),
-                    instead: arg.to_owned(),
-                }),
-                tip: format!("try `{} {}`", "help".bold(), label.bold()),
-            }),
-        },
-        None => Ok(1),
-    }?;
+
+            *num as _
+        }
+        None => 1,
+        _ => unreachable!(),
+    };
 
     let mut backs = 0;
     let mut ran_out_of_history = false;
@@ -325,7 +281,7 @@ fn step_back(state: &mut State, label: &str, args: &[String]) -> Result<String, 
     Ok("".into())
 }
 
-fn step_syscall(state: &mut State, label: &str, _args: &[String]) -> Result<String, CommandError> {
+fn step_syscall(state: &mut State, label: &str) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(get_step_help_text(
             format!(
@@ -364,7 +320,7 @@ fn step_syscall(state: &mut State, label: &str, _args: &[String]) -> Result<Stri
     step_till_condition(state, |_| true)
 }
 
-fn step_input(state: &mut State, label: &str, _args: &[String]) -> Result<String, CommandError> {
+fn step_input(state: &mut State, label: &str) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(get_step_help_text(
             "Steps forwards until your program asks for its next input, or finishes.",
@@ -374,7 +330,7 @@ fn step_input(state: &mut State, label: &str, _args: &[String]) -> Result<String
     step_till_condition(state, |syscall| matches!(syscall, 5 | 6 | 7 | 8 | 12))
 }
 
-fn step_output(state: &mut State, label: &str, _args: &[String]) -> Result<String, CommandError> {
+fn step_output(state: &mut State, label: &str) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(get_step_help_text(
             "Steps forwards until your program asks for its next output, or finishes.",
@@ -384,7 +340,7 @@ fn step_output(state: &mut State, label: &str, _args: &[String]) -> Result<Strin
     step_till_condition(state, |syscall| matches!(syscall, 1 | 2 | 3 | 4 | 11))
 }
 
-fn step_integer(state: &mut State, label: &str, _args: &[String]) -> Result<String, CommandError> {
+fn step_integer(state: &mut State, label: &str) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(get_step_help_text(
             "Steps forwards until your program executes a syscall that requires\n\
@@ -395,7 +351,7 @@ fn step_integer(state: &mut State, label: &str, _args: &[String]) -> Result<Stri
     step_till_condition(state, |syscall| matches!(syscall, 1 | 5))
 }
 
-fn step_float(state: &mut State, label: &str, _args: &[String]) -> Result<String, CommandError> {
+fn step_float(state: &mut State, label: &str) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(get_step_help_text(
             "Steps forwards until your program executes a syscall that requires\n\
@@ -406,7 +362,7 @@ fn step_float(state: &mut State, label: &str, _args: &[String]) -> Result<String
     step_till_condition(state, |syscall| matches!(syscall, 2 | 6))
 }
 
-fn step_double(state: &mut State, label: &str, _args: &[String]) -> Result<String, CommandError> {
+fn step_double(state: &mut State, label: &str) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(get_step_help_text(
             "Steps forwards until your program executes a syscall that requires\n\
@@ -417,7 +373,7 @@ fn step_double(state: &mut State, label: &str, _args: &[String]) -> Result<Strin
     step_till_condition(state, |syscall| matches!(syscall, 3 | 7))
 }
 
-fn step_string(state: &mut State, label: &str, _args: &[String]) -> Result<String, CommandError> {
+fn step_string(state: &mut State, label: &str) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(get_step_help_text(
             "Steps forwards until your program executes a syscall that requires\n\
@@ -428,11 +384,7 @@ fn step_string(state: &mut State, label: &str, _args: &[String]) -> Result<Strin
     step_till_condition(state, |syscall| matches!(syscall, 4 | 8))
 }
 
-fn step_character(
-    state: &mut State,
-    label: &str,
-    _args: &[String],
-) -> Result<String, CommandError> {
+fn step_character(state: &mut State, label: &str) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(get_step_help_text(
             "Steps forwards until your program executes a syscall that requires\n\
@@ -443,7 +395,7 @@ fn step_character(
     step_till_condition(state, |syscall| matches!(syscall, 11 | 12))
 }
 
-fn step_file(state: &mut State, label: &str, _args: &[String]) -> Result<String, CommandError> {
+fn step_file(state: &mut State, label: &str) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(get_step_help_text(
             "Steps forwards until your program executes a syscall that opens,\n\

--- a/crates/mipsy_interactive/src/interactive/commands/step.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/step.rs
@@ -12,23 +12,57 @@ pub(super) fn args_numbers(args: &[ArgumentKind]) -> Vec<i64> {
     args.iter().cloned().map(i64::from).collect()
 }
 
+fn subcmd_help() -> String {
+    get_step_help_text(
+        format!(
+            "\
+                Available {1}s are:\n\
+                \n\
+                {0} {2}     : syscalls 5, 6, 7, 8, 12\n\
+                {0} {3}    : syscalls 1, 2, 3, 4, 11\n\
+                {0} {4}   : syscalls 1, 5\n\
+                {0} {5}     : syscalls 2, 6\n\
+                {0} {6}    : syscalls 3, 7\n\
+                {0} {7}    : syscalls 4, 8\n\
+                {0} {8} : syscalls 11, 12\n\
+                {0} {9}      : syscalls 13, 14, 15, 16\n\
+                \n\
+                {10} {11} will provide more information about the specified subcommand.\n\
+                \n\
+                By default, this steps forwards until your program's next syscall, or finishes.",
+            "step syscall".bold().yellow(),
+            "[type]".magenta(),
+            "input".purple(),
+            "output".purple(),
+            "integer".purple(),
+            "float".purple(),
+            "double".purple(),
+            "string".purple(),
+            "character".purple(),
+            "file".purple(),
+            "help step syscall".white().bold(),
+            "[type]".magenta().bold(),
+        )
+        .as_ref(),
+    )
+}
+
 fn call_subcmds(
     cmd: &Command,
     state: &mut State,
     helper: &MyHelper,
-    label: &str,
     args: &[ArgumentKind],
 ) -> CommandResult<String> {
     match args.get(0) {
         Some(ArgumentKind::String(arg)) => {
             if let Some(cmd) = cmd.subcommands.iter().find(|c| c.names.contains(arg)) {
-                return (cmd._internal_exec)(cmd, state, helper, label, &args[1..]);
+                return (cmd._internal_exec)(cmd, state, helper, &args[1..]);
             }
         }
         None | Some(ArgumentKind::Number(_)) => {}
     }
 
-    step_syscall(state, label, helper)
+    step_syscall(state, helper)
 }
 
 fn subcmd() -> Command {
@@ -40,47 +74,78 @@ fn subcmd() -> Command {
             Command::new()
                 .with_name("input")
                 .with_name("in")
-                .with_exec(|_, state, helper, label, _| step_input(state, label, helper)),
+                .with_help(get_step_help_text(
+                    "Steps forwards until your program asks for its next input, or finishes.",
+                ))
+                .with_exec(|_, state, helper, _| step_input(state, helper)),
         )
         .with_subcommand(
             Command::new()
                 .with_name("output")
                 .with_name("out")
-                .with_exec(|_, state, helper, label, _| step_output(state, label, helper)),
+                .with_name(get_step_help_text(
+                    "Steps forwards until your program asks for its next output, or finishes.",
+                ))
+                .with_exec(|_, state, helper, _| step_output(state, helper)),
         )
         .with_subcommand(
             Command::new()
                 .with_name("integer")
                 .with_name("int")
-                .with_exec(|_, state, helper, label, _| step_integer(state, label, helper)),
+                .with_help(get_step_help_text(
+                    "Steps forwards until your program executes a syscall that requires\n\
+                 reading or writing an integer, or finishes.",
+                ))
+                .with_exec(|_, state, helper, _| step_integer(state, helper)),
         )
         .with_subcommand(
             Command::new()
                 .with_name("float")
-                .with_exec(|_, state, helper, label, _| step_float(state, label, helper)),
+                .with_help(get_step_help_text(
+                    "Steps forwards until your program executes a syscall that requires\n\
+                 reading or writing a float, or finishes.",
+                ))
+                .with_exec(|_, state, helper, _| step_float(state, helper)),
         )
         .with_subcommand(
             Command::new()
                 .with_name("double")
-                .with_exec(|_, state, helper, label, _| step_double(state, label, helper)),
+                .with_help(get_step_help_text(
+                    "Steps forwards until your program executes a syscall that requires\n\
+                 reading or writing a double, or finishes.",
+                ))
+                .with_exec(|_, state, helper, _| step_double(state, helper)),
         )
         .with_subcommand(
             Command::new()
                 .with_name("string")
                 .with_name("str")
-                .with_exec(|_, state, helper, label, _| step_string(state, label, helper)),
+                .with_help(get_step_help_text(
+                    "Steps forwards until your program executes a syscall that requires\n\
+                 reading or writing a string, or finishes.",
+                ))
+                .with_exec(|_, state, helper, _| step_string(state, helper)),
         )
         .with_subcommand(
             Command::new()
                 .with_name("character")
                 .with_name("char")
-                .with_exec(|_, state, helper, label, _| step_character(state, label, helper)),
+                .with_help(get_step_help_text(
+                    "Steps forwards until your program executes a syscall that requires\n\
+                 reading or writing a character, or finishes.",
+                ))
+                .with_exec(|_, state, helper, _| step_character(state, helper)),
         )
         .with_subcommand(
             Command::new()
                 .with_name("file")
-                .with_exec(|_, state, helper, label, _| step_file(state, label, helper)),
+                .with_help(get_step_help_text(
+                    "Steps forwards until your program executes a syscall that opens,\n\
+                 reads from, writes to, or closes a file, or finishes.",
+                ))
+                .with_exec(|_, state, helper, _| step_file(state, helper)),
         )
+        .with_help(subcmd_help())
         .with_exec(call_subcmds)
 }
 
@@ -113,11 +178,18 @@ pub(crate) fn command() -> Command {
                 .with_name("back")
                 .with_name("b")
                 .with_optional_arg(times_arg)
-                .with_exec(|_, state, helper, label, args| {
-                    step_back(state, label, &args_numbers(args), helper)
-                }),
+                .with_help(format!(
+                    "Steps backwards one instruction, or {0} instructions if specified.\n\
+                 It will then print out which instruction will be executed next --\n\
+             \x20 i.e. using `{1}` will immediately execute said printed instruction.\n\
+                 To step fowards (i.e. normal stepping), use `{1}`.",
+                    "[times]".magenta(),
+                    "step".bold(),
+                ))
+                .with_exec(|_, state, helper, args| step_back(state, &args_numbers(args), helper)),
         )
         .with_subcommand(subcmd())
+        .with_help(subcmd_help())
         .with_exec(call_subcmds)
 }
 
@@ -147,7 +219,6 @@ fn get_long_help() -> String {
 
 fn step_forward(
     state: &mut State,
-    label: &str,
     args: &[i64],
     helper: &MyHelper,
 ) -> Result<String, CommandError> {
@@ -159,7 +230,6 @@ fn step_forward(
     if times.is_negative() {
         return step_back(
             state,
-            label,
             [times]
                 .into_iter()
                 .chain(args.iter().skip(1).cloned())
@@ -198,28 +268,11 @@ fn step_forward(
     Ok("".into())
 }
 
-fn step_back(
-    state: &mut State,
-    label: &str,
-    args: &[i64],
-    helper: &MyHelper,
-) -> CommandResult<String> {
-    if label == "__help__" {
-        return Ok(format!(
-            "Steps backwards one instruction, or {0} instructions if specified.\n\
-                 It will then print out which instruction will be executed next --\n\
-             \x20 i.e. using `{1}` will immediately execute said printed instruction.\n\
-                 To step fowards (i.e. normal stepping), use `{1}`.",
-            "[times]".magenta(),
-            "step".bold(),
-        ));
-    }
-
+fn step_back(state: &mut State, args: &[i64], helper: &MyHelper) -> CommandResult<String> {
     let times = *args.first().or(Some(&1)).unwrap();
     if times.is_negative() {
         return step_forward(
             state,
-            label,
             [times.abs()]
                 .into_iter()
                 .chain(args.iter().skip(1).cloned())
@@ -289,52 +342,11 @@ fn step_back(
     Ok("".into())
 }
 
-fn step_syscall(state: &mut State, label: &str, helper: &MyHelper) -> Result<String, CommandError> {
-    if label == "__help__" {
-        return Ok(get_step_help_text(
-            format!(
-                "\
-                Available {1}s are:\n\
-                \n\
-                {0} {2}     : syscalls 5, 6, 7, 8, 12\n\
-                {0} {3}    : syscalls 1, 2, 3, 4, 11\n\
-                {0} {4}   : syscalls 1, 5\n\
-                {0} {5}     : syscalls 2, 6\n\
-                {0} {6}    : syscalls 3, 7\n\
-                {0} {7}    : syscalls 4, 8\n\
-                {0} {8} : syscalls 11, 12\n\
-                {0} {9}      : syscalls 13, 14, 15, 16\n\
-                \n\
-                {10} {11} will provide more information about the specified subcommand.\n\
-                \n\
-                By default, this steps forwards until your program's next syscall, or finishes.",
-                "step syscall".bold().yellow(),
-                "[type]".magenta(),
-                "input".purple(),
-                "output".purple(),
-                "integer".purple(),
-                "float".purple(),
-                "double".purple(),
-                "string".purple(),
-                "character".purple(),
-                "file".purple(),
-                "help step syscall".white().bold(),
-                "[type]".magenta().bold(),
-            )
-            .as_ref(),
-        ));
-    }
-
+fn step_syscall(state: &mut State, helper: &MyHelper) -> Result<String, CommandError> {
     step_till_condition(state, |_| true, helper)
 }
 
-fn step_input(state: &mut State, label: &str, helper: &MyHelper) -> Result<String, CommandError> {
-    if label == "__help__" {
-        return Ok(get_step_help_text(
-            "Steps forwards until your program asks for its next input, or finishes.",
-        ));
-    }
-
+fn step_input(state: &mut State, helper: &MyHelper) -> Result<String, CommandError> {
     step_till_condition(
         state,
         |syscall| matches!(syscall, 5 | 6 | 7 | 8 | 12),
@@ -342,13 +354,7 @@ fn step_input(state: &mut State, label: &str, helper: &MyHelper) -> Result<Strin
     )
 }
 
-fn step_output(state: &mut State, label: &str, helper: &MyHelper) -> Result<String, CommandError> {
-    if label == "__help__" {
-        return Ok(get_step_help_text(
-            "Steps forwards until your program asks for its next output, or finishes.",
-        ));
-    }
-
+fn step_output(state: &mut State, helper: &MyHelper) -> Result<String, CommandError> {
     step_till_condition(
         state,
         |syscall| matches!(syscall, 1 | 2 | 3 | 4 | 11),
@@ -356,73 +362,27 @@ fn step_output(state: &mut State, label: &str, helper: &MyHelper) -> Result<Stri
     )
 }
 
-fn step_integer(state: &mut State, label: &str, helper: &MyHelper) -> Result<String, CommandError> {
-    if label == "__help__" {
-        return Ok(get_step_help_text(
-            "Steps forwards until your program executes a syscall that requires\n\
-                 reading or writing an integer, or finishes.",
-        ));
-    }
-
+fn step_integer(state: &mut State, helper: &MyHelper) -> Result<String, CommandError> {
     step_till_condition(state, |syscall| matches!(syscall, 1 | 5), helper)
 }
 
-fn step_float(state: &mut State, label: &str, helper: &MyHelper) -> Result<String, CommandError> {
-    if label == "__help__" {
-        return Ok(get_step_help_text(
-            "Steps forwards until your program executes a syscall that requires\n\
-                 reading or writing a float, or finishes.",
-        ));
-    }
-
+fn step_float(state: &mut State, helper: &MyHelper) -> Result<String, CommandError> {
     step_till_condition(state, |syscall| matches!(syscall, 2 | 6), helper)
 }
 
-fn step_double(state: &mut State, label: &str, helper: &MyHelper) -> Result<String, CommandError> {
-    if label == "__help__" {
-        return Ok(get_step_help_text(
-            "Steps forwards until your program executes a syscall that requires\n\
-                 reading or writing a double, or finishes.",
-        ));
-    }
-
+fn step_double(state: &mut State, helper: &MyHelper) -> Result<String, CommandError> {
     step_till_condition(state, |syscall| matches!(syscall, 3 | 7), helper)
 }
 
-fn step_string(state: &mut State, label: &str, helper: &MyHelper) -> Result<String, CommandError> {
-    if label == "__help__" {
-        return Ok(get_step_help_text(
-            "Steps forwards until your program executes a syscall that requires\n\
-                 reading or writing a string, or finishes.",
-        ));
-    }
-
+fn step_string(state: &mut State, helper: &MyHelper) -> Result<String, CommandError> {
     step_till_condition(state, |syscall| matches!(syscall, 4 | 8), helper)
 }
 
-fn step_character(
-    state: &mut State,
-    label: &str,
-    helper: &MyHelper,
-) -> Result<String, CommandError> {
-    if label == "__help__" {
-        return Ok(get_step_help_text(
-            "Steps forwards until your program executes a syscall that requires\n\
-                 reading or writing a character, or finishes.",
-        ));
-    }
-
+fn step_character(state: &mut State, helper: &MyHelper) -> Result<String, CommandError> {
     step_till_condition(state, |syscall| matches!(syscall, 11 | 12), helper)
 }
 
-fn step_file(state: &mut State, label: &str, helper: &MyHelper) -> Result<String, CommandError> {
-    if label == "__help__" {
-        return Ok(get_step_help_text(
-            "Steps forwards until your program executes a syscall that opens,\n\
-                 reads from, writes to, or closes a file, or finishes.",
-        ));
-    }
-
+fn step_file(state: &mut State, helper: &MyHelper) -> Result<String, CommandError> {
     step_till_condition(
         state,
         |syscall| matches!(syscall, 13 | 14 | 15 | 16),

--- a/crates/mipsy_interactive/src/interactive/commands/step.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/step.rs
@@ -14,8 +14,7 @@ pub(super) fn args_numbers(args: &[ArgumentKind]) -> Vec<i64> {
 
 fn call_subcmds(
     cmd: &Command,
-    state: &mut State,
-    helper: &MyHelper,
+    helper: &mut MyHelper,
     args: &[ArgumentKind],
 ) -> CommandResult<String> {
     if let Some(arg) = args.get(0) {
@@ -24,97 +23,14 @@ fn call_subcmds(
             .iter()
             .find(|c| c.names.contains(&arg.clone().into()))
         {
-            return (cmd._internal_exec)(cmd, state, helper, &args[1..]);
+            return (cmd._internal_exec)(cmd, helper, &args[1..]);
         }
     }
 
-    step_syscall(state, helper)
+    step_syscall(helper)
 }
 
 pub(crate) fn command() -> Command {
-    let subcmd = Command::new()
-        .with_name("syscall")
-        .with_name("s")
-        .with_name("sys")
-        .with_help(subcmd_help())
-        .with_subcommand(
-            Command::new()
-                .with_name("input")
-                .with_name("in")
-                .with_help(get_step_help_text(
-                    "Steps forwards until your program asks for its next input, or finishes.",
-                ))
-                .with_exec(|_, state, helper, _| step_input(state, helper)),
-        )
-        .with_subcommand(
-            Command::new()
-                .with_name("output")
-                .with_name("out")
-                .with_name(get_step_help_text(
-                    "Steps forwards until your program asks for its next output, or finishes.",
-                ))
-                .with_exec(|_, state, helper, _| step_output(state, helper)),
-        )
-        .with_subcommand(
-            Command::new()
-                .with_name("integer")
-                .with_name("int")
-                .with_help(get_step_help_text(
-                    "Steps forwards until your program executes a syscall that requires\n\
-                 reading or writing an integer, or finishes.",
-                ))
-                .with_exec(|_, state, helper, _| step_integer(state, helper)),
-        )
-        .with_subcommand(
-            Command::new()
-                .with_name("float")
-                .with_help(get_step_help_text(
-                    "Steps forwards until your program executes a syscall that requires\n\
-                 reading or writing a float, or finishes.",
-                ))
-                .with_exec(|_, state, helper, _| step_float(state, helper)),
-        )
-        .with_subcommand(
-            Command::new()
-                .with_name("double")
-                .with_help(get_step_help_text(
-                    "Steps forwards until your program executes a syscall that requires\n\
-                 reading or writing a double, or finishes.",
-                ))
-                .with_exec(|_, state, helper, _| step_double(state, helper)),
-        )
-        .with_subcommand(
-            Command::new()
-                .with_name("string")
-                .with_name("str")
-                .with_help(get_step_help_text(
-                    "Steps forwards until your program executes a syscall that requires\n\
-                 reading or writing a string, or finishes.",
-                ))
-                .with_exec(|_, state, helper, _| step_string(state, helper)),
-        )
-        .with_subcommand(
-            Command::new()
-                .with_name("character")
-                .with_name("char")
-                .with_help(get_step_help_text(
-                    "Steps forwards until your program executes a syscall that requires\n\
-                 reading or writing a character, or finishes.",
-                ))
-                .with_exec(|_, state, helper, _| step_character(state, helper)),
-        )
-        .with_subcommand(
-            Command::new()
-                .with_name("file")
-                .with_help(get_step_help_text(
-                    "Steps forwards until your program executes a syscall that opens,\n\
-                 reads from, writes to, or closes a file, or finishes.",
-                ))
-                .with_exec(|_, state, helper, _| step_file(state, helper)),
-        )
-        .with_required_arg(Argument::subcommands())
-        .with_exec(call_subcmds);
-
     let times_arg = Argument::new(
         "times",
         |_, a, _| match a.parse::<i32>() {
@@ -139,22 +55,105 @@ pub(crate) fn command() -> Command {
         .with_optional_arg(Argument::subcommands())
         .with_subcommand(
             Command::new()
-                .with_name("back")
-                .with_name("b")
-                .with_optional_arg(times_arg)
-                .with_help(format!(
+            .with_name("back")
+            .with_name("b")
+            .with_optional_arg(times_arg)
+            .with_help(format!(
                     "Steps backwards one instruction, or {0} instructions if specified.\n\
-                 It will then print out which instruction will be executed next --\n\
-             \x20 i.e. using `{1}` will immediately execute said printed instruction.\n\
-                 To step fowards (i.e. normal stepping), use `{1}`.",
+                    It will then print out which instruction will be executed next --\n\
+                    \x20 i.e. using `{1}` will immediately execute said printed instruction.\n\
+                    To step fowards (i.e. normal stepping), use `{1}`.",
                     "[times]".magenta(),
                     "step".bold(),
-                ))
-                .with_exec(|_, state, helper, args| step_back(state, &args_numbers(args), helper)),
+            ))
+            .with_exec(|_, helper, args| step_back(helper, &args_numbers(args))),
         )
-        .with_subcommand(subcmd)
         .with_help(get_long_help())
         .with_exec(call_subcmds)
+        .with_subcommand(
+            Command::new()
+            .with_name("syscall")
+            .with_name("s")
+            .with_name("sys")
+            .with_help(subcmd_help())
+            .with_subcommand(
+                Command::new()
+                .with_name("input")
+                .with_name("in")
+                .with_help(get_step_help_text(
+                        "Steps forwards until your program asks for its next input, or finishes.",
+                ))
+                .with_exec(|_, helper, _| step_input(helper)),
+            )
+            .with_subcommand(
+                Command::new()
+                .with_name("output")
+                .with_name("out")
+                .with_name(get_step_help_text(
+                        "Steps forwards until your program asks for its next output, or finishes.",
+                ))
+                .with_exec(|_, helper, _| step_output(helper)),
+            )
+            .with_subcommand(
+                Command::new()
+                .with_name("integer")
+                .with_name("int")
+                .with_help(get_step_help_text(
+                        "Steps forwards until your program executes a syscall that requires\n\
+                        reading or writing an integer, or finishes.",
+                ))
+                .with_exec(|_, helper, _| step_integer(helper)),
+            )
+            .with_subcommand(
+                Command::new()
+                .with_name("float")
+                .with_help(get_step_help_text(
+                        "Steps forwards until your program executes a syscall that requires\n\
+                        reading or writing a float, or finishes.",
+                ))
+                .with_exec(|_, helper, _| step_float(helper)),
+            )
+            .with_subcommand(
+                Command::new()
+                .with_name("double")
+                .with_help(get_step_help_text(
+                        "Steps forwards until your program executes a syscall that requires\n\
+                        reading or writing a double, or finishes.",
+                ))
+                .with_exec(|_, helper, _| step_double(helper)),
+            )
+            .with_subcommand(
+                Command::new()
+                .with_name("string")
+                .with_name("str")
+                .with_help(get_step_help_text(
+                        "Steps forwards until your program executes a syscall that requires\n\
+                        reading or writing a string, or finishes.",
+                ))
+                .with_exec(|_, helper, _| step_string(helper)),
+            )
+            .with_subcommand(
+                Command::new()
+                .with_name("character")
+                .with_name("char")
+                .with_help(get_step_help_text(
+                        "Steps forwards until your program executes a syscall that requires\n\
+                        reading or writing a character, or finishes.",
+                ))
+                .with_exec(|_, helper, _| step_character(helper)),
+            )
+            .with_subcommand(
+                Command::new()
+                .with_name("file")
+                .with_help(get_step_help_text(
+                        "Steps forwards until your program executes a syscall that opens,\n\
+                        reads from, writes to, or closes a file, or finishes.",
+                ))
+                .with_exec(|_, helper, _| step_file(helper)),
+            )
+            .with_required_arg(Argument::subcommands())
+            .with_exec(call_subcmds)
+            )
 }
 
 fn get_long_help() -> String {
@@ -181,11 +180,7 @@ fn get_long_help() -> String {
     )
 }
 
-fn step_forward(
-    state: &mut State,
-    args: &[i64],
-    helper: &MyHelper,
-) -> Result<String, CommandError> {
+fn step_forward(helper: &mut MyHelper, args: &[i64]) -> Result<String, CommandError> {
     let times = args
         .first()
         .and_then(|&n| Some(i64::from(n)))
@@ -193,38 +188,41 @@ fn step_forward(
         .unwrap();
     if times.is_negative() {
         return step_back(
-            state,
+            helper,
             [times]
                 .into_iter()
                 .chain(args.iter().skip(1).cloned())
                 .collect::<Vec<_>>()
                 .as_ref(),
-            helper,
         );
     }
 
-    if state.exited {
+    if helper.state.exited {
         return Err(CommandError::ProgramExited);
     }
 
-    state.interrupted.store(false, Ordering::SeqCst);
+    helper.state.interrupted.store(false, Ordering::SeqCst);
     for _ in 0..times {
-        let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
-        let runtime = &state.runtime;
+        let binary = helper
+            .state
+            .binary
+            .as_ref()
+            .ok_or(CommandError::MustLoadFile)?;
+        let runtime = &helper.state.runtime;
 
         if let Ok(inst) = runtime.next_inst() {
             util::print_inst(
-                &state.iset,
+                &helper.state.iset,
                 binary,
                 inst,
                 runtime.timeline().state().pc(),
-                state.program.as_deref(),
+                helper.state.program.as_deref(),
             );
         }
 
-        let step = state.step(true, helper)?;
+        let step = State::step(helper, true)?;
 
-        if step | state.interrupted.load(Ordering::SeqCst) {
+        if step | helper.state.interrupted.load(Ordering::SeqCst) {
             break;
         }
     }
@@ -232,25 +230,24 @@ fn step_forward(
     Ok("".into())
 }
 
-fn step_back(state: &mut State, args: &[i64], helper: &MyHelper) -> CommandResult<String> {
+fn step_back(helper: &mut MyHelper, args: &[i64]) -> CommandResult<String> {
     let times = *args.first().or(Some(&1)).unwrap();
     if times.is_negative() {
         return step_forward(
-            state,
+            helper,
             [times.abs()]
                 .into_iter()
                 .chain(args.iter().skip(1).cloned())
                 .collect::<Vec<_>>()
                 .as_ref(),
-            helper,
         );
     }
 
     let mut backs = 0;
     let mut ran_out_of_history = false;
-    state.interrupted.store(false, Ordering::SeqCst);
+    helper.state.interrupted.store(false, Ordering::SeqCst);
     for _ in 0..times {
-        let runtime = &mut state.runtime;
+        let runtime = &mut helper.state.runtime;
 
         if runtime.timeline().timeline_len() == 2 && runtime.timeline().lost_history() {
             if backs == 0 {
@@ -263,18 +260,22 @@ fn step_back(state: &mut State, args: &[i64], helper: &MyHelper) -> CommandResul
 
         if runtime.timeline_mut().pop_last_state() {
             backs += 1;
-            state.exited = false;
+            helper.state.exited = false;
         } else if backs == 0 {
             return Err(CommandError::CannotStepFurtherBack);
         }
 
-        if state.interrupted.load(Ordering::SeqCst) {
+        if helper.state.interrupted.load(Ordering::SeqCst) {
             break;
         }
     }
 
-    let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
-    let runtime = &state.runtime;
+    let binary = helper
+        .state
+        .binary
+        .as_ref()
+        .ok_or(CommandError::MustLoadFile)?;
+    let runtime = &helper.state.runtime;
 
     let pluralise = if backs != 1 { "s" } else { "" };
 
@@ -294,11 +295,11 @@ fn step_back(state: &mut State, args: &[i64], helper: &MyHelper) -> CommandResul
     prompt::success(text);
     if let Ok(inst) = runtime.next_inst() {
         util::print_inst(
-            &state.iset,
+            &helper.state.iset,
             binary,
             inst,
             runtime.timeline().state().pc(),
-            state.program.as_deref(),
+            helper.state.program.as_deref(),
         );
     }
     println!();
@@ -306,78 +307,66 @@ fn step_back(state: &mut State, args: &[i64], helper: &MyHelper) -> CommandResul
     Ok("".into())
 }
 
-fn step_syscall(state: &mut State, helper: &MyHelper) -> Result<String, CommandError> {
-    step_till_condition(state, |_| true, helper)
+fn step_syscall(helper: &mut MyHelper) -> Result<String, CommandError> {
+    step_till_condition(helper, |_| true)
 }
 
-fn step_input(state: &mut State, helper: &MyHelper) -> Result<String, CommandError> {
-    step_till_condition(
-        state,
-        |syscall| matches!(syscall, 5 | 6 | 7 | 8 | 12),
-        helper,
-    )
+fn step_input(helper: &mut MyHelper) -> Result<String, CommandError> {
+    step_till_condition(helper, |syscall| matches!(syscall, 5 | 6 | 7 | 8 | 12))
 }
 
-fn step_output(state: &mut State, helper: &MyHelper) -> Result<String, CommandError> {
-    step_till_condition(
-        state,
-        |syscall| matches!(syscall, 1 | 2 | 3 | 4 | 11),
-        helper,
-    )
+fn step_output(helper: &mut MyHelper) -> Result<String, CommandError> {
+    step_till_condition(helper, |syscall| matches!(syscall, 1 | 2 | 3 | 4 | 11))
 }
 
-fn step_integer(state: &mut State, helper: &MyHelper) -> Result<String, CommandError> {
-    step_till_condition(state, |syscall| matches!(syscall, 1 | 5), helper)
+fn step_integer(helper: &mut MyHelper) -> Result<String, CommandError> {
+    step_till_condition(helper, |syscall| matches!(syscall, 1 | 5))
 }
 
-fn step_float(state: &mut State, helper: &MyHelper) -> Result<String, CommandError> {
-    step_till_condition(state, |syscall| matches!(syscall, 2 | 6), helper)
+fn step_float(helper: &mut MyHelper) -> Result<String, CommandError> {
+    step_till_condition(helper, |syscall| matches!(syscall, 2 | 6))
 }
 
-fn step_double(state: &mut State, helper: &MyHelper) -> Result<String, CommandError> {
-    step_till_condition(state, |syscall| matches!(syscall, 3 | 7), helper)
+fn step_double(helper: &mut MyHelper) -> Result<String, CommandError> {
+    step_till_condition(helper, |syscall| matches!(syscall, 3 | 7))
 }
 
-fn step_string(state: &mut State, helper: &MyHelper) -> Result<String, CommandError> {
-    step_till_condition(state, |syscall| matches!(syscall, 4 | 8), helper)
+fn step_string(helper: &mut MyHelper) -> Result<String, CommandError> {
+    step_till_condition(helper, |syscall| matches!(syscall, 4 | 8))
 }
 
-fn step_character(state: &mut State, helper: &MyHelper) -> Result<String, CommandError> {
-    step_till_condition(state, |syscall| matches!(syscall, 11 | 12), helper)
+fn step_character(helper: &mut MyHelper) -> Result<String, CommandError> {
+    step_till_condition(helper, |syscall| matches!(syscall, 11 | 12))
 }
 
-fn step_file(state: &mut State, helper: &MyHelper) -> Result<String, CommandError> {
-    step_till_condition(
-        state,
-        |syscall| matches!(syscall, 13 | 14 | 15 | 16),
-        helper,
-    )
+fn step_file(helper: &mut MyHelper) -> Result<String, CommandError> {
+    step_till_condition(helper, |syscall| matches!(syscall, 13 | 14 | 15 | 16))
 }
 
-fn step_till_condition<F>(
-    state: &mut State,
-    condition: F,
-    helper: &MyHelper,
-) -> Result<String, CommandError>
+fn step_till_condition<F>(helper: &mut MyHelper, condition: F) -> Result<String, CommandError>
 where
     F: Fn(i32) -> bool,
 {
-    if state.exited {
+    if helper.state.exited {
         return Err(CommandError::ProgramExited);
     }
 
-    state.interrupted.store(false, Ordering::SeqCst);
-    while !state.interrupted.load(Ordering::SeqCst) {
-        let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
-        let runtime = &state.runtime;
+    helper.state.interrupted.store(false, Ordering::SeqCst);
+    while !helper.state.interrupted.load(Ordering::SeqCst) {
+        let binary = helper
+            .state
+            .binary
+            .as_ref()
+            .ok_or(CommandError::MustLoadFile)?;
+        let runtime = &helper.state.runtime;
 
         let stop = if let Ok(inst) = runtime.next_inst() {
             util::print_inst(
-                &state.iset,
+                &helper.state.iset,
                 binary,
                 inst,
                 runtime.timeline().state().pc(),
-                state.program.as_deref(),
+                helper.state.program.as_deref(),
             );
 
             if inst == 0xC {
@@ -394,7 +383,7 @@ where
             false
         };
 
-        let step = state.step(true, helper)?;
+        let step = State::step(helper, true)?;
 
         if step || stop {
             break;

--- a/crates/mipsy_interactive/src/interactive/commands/step.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/step.rs
@@ -27,8 +27,8 @@ fn call_subcmds(
     step_syscall(state, label)
 }
 
-pub(crate) fn command() -> Command {
-    let subcmd = Command::new()
+fn subcmd() -> Command {
+    Command::new()
         .with_name("syscall")
         .with_name("s")
         .with_name("sys")
@@ -77,19 +77,25 @@ pub(crate) fn command() -> Command {
                 .with_name("file")
                 .with_exec(|_, state, label, _| step_file(state, label)),
         )
-        .with_exec(call_subcmds);
+        .with_exec(call_subcmds)
+}
 
-    let times_arg = Argument::new("times", |a| match a.parse::<i32>() {
-        Ok(i) => Ok(ArgumentKind::Number(i as _)),
-        Err(_) => Err(CommandError::WithTip {
-            error: Box::new(CommandError::ArgExpectedI32 {
-                arg: "[times]".bright_magenta().to_string(),
-                instead: a.to_owned(),
+pub(crate) fn command() -> Command {
+    let times_arg = Argument::new(
+        "times",
+        |a| match a.parse::<i32>() {
+            Ok(i) => Ok(ArgumentKind::Number(i as _)),
+            Err(_) => Err(CommandError::WithTip {
+                error: Box::new(CommandError::ArgExpectedI32 {
+                    arg: "[times]".bright_magenta().to_string(),
+                    instead: a.to_owned(),
+                }),
+                // tip: format!("try `{} {}`", "help".bold(), label.bold()),
+                tip: format!("try TODOTODOIJJDSKJAKDJTODOOOOOOOOOOOOOTODOOOOOOOOOOOO"),
             }),
-            // tip: format!("try `{} {}`", "help".bold(), label.bold()),
-            tip: format!("try TODOTODOIJJDSKJAKDJTODOOOOOOOOOOOOOTODOOOOOOOOOOOO"),
-        }),
-    });
+        },
+        |_, _| vec![],
+    );
 
     Command::new()
         .with_name("step")
@@ -97,9 +103,7 @@ pub(crate) fn command() -> Command {
         .with_name("s")
         .with_name("back")
         .with_optional_arg(times_arg.clone())
-        .with_optional_arg(Argument::new("subcommand", |a| {
-            Ok(ArgumentKind::SubCommand(a.to_owned()))
-        }))
+        .with_optional_arg(Argument::subcommands())
         .with_subcommand(
             Command::new()
                 .with_name("back")
@@ -107,7 +111,7 @@ pub(crate) fn command() -> Command {
                 .with_optional_arg(times_arg)
                 .with_exec(|_, state, label, args| step_back(state, label, args)),
         )
-        .with_subcommand(subcmd.clone())
+        .with_subcommand(subcmd())
         .with_exec(call_subcmds)
 }
 

--- a/crates/mipsy_interactive/src/interactive/commands/step.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/step.rs
@@ -153,7 +153,7 @@ pub(crate) fn command() -> Command {
             )
             .with_required_arg(Argument::subcommands())
             .with_exec(call_subcmds)
-            )
+        )
 }
 
 fn get_long_help() -> String {

--- a/crates/mipsy_interactive/src/interactive/commands/step.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/step.rs
@@ -9,7 +9,11 @@ use colored::*;
 use mipsy_lib::Register;
 
 pub(super) fn args_numbers(args: &[ArgumentKind]) -> Vec<i64> {
-    args.iter().cloned().map(i64::from).collect()
+    args.iter()
+        .cloned()
+        .map(i64::try_from)
+        .map(Result::unwrap)
+        .collect()
 }
 
 fn call_subcmds(
@@ -17,12 +21,8 @@ fn call_subcmds(
     helper: &mut MyHelper,
     args: &[ArgumentKind],
 ) -> CommandResult<String> {
-    if let Some(arg) = args.get(0) {
-        if let Some(cmd) = cmd
-            .subcommands
-            .iter()
-            .find(|c| c.names.contains(&arg.clone().into()))
-        {
+    if let Some(ArgumentKind::String(arg)) = args.get(0) {
+        if let Some(cmd) = cmd.subcommands.iter().find(|c| c.names.contains(arg)) {
             return (cmd._internal_exec)(cmd, helper, &args[1..]);
         }
     }
@@ -33,8 +33,11 @@ fn call_subcmds(
 pub(crate) fn command() -> Command {
     let times_arg = Argument::new(
         "times",
-        |_, a, _| match a.parse::<i32>() {
-            Ok(i) => Ok(ArgumentKind::Number(i as _)),
+        |a, _| match a.parse::<i32>() {
+            Ok(i) => {
+                println!("{a}");
+                Ok(ArgumentKind::Number(i as _))
+            }
             Err(_) => Err(CommandError::WithTip {
                 error: Box::new(CommandError::ArgExpectedI32 {
                     arg: "[times]".bright_magenta().to_string(),
@@ -43,17 +46,17 @@ pub(crate) fn command() -> Command {
                 tip: format!("try `{} {}`", "help".bold(), "step".bold()),
             }),
         },
-        |_, _, _| vec![],
+        |_, _| vec![],
     );
 
     Command::new()
         .with_name("step")
-        .with_desc("step forwards or execute a subcommand")
         .with_name("s")
-        .with_name("back")
+        .with_desc("step forwards or execute a subcommand")
         .with_optional_arg(times_arg.clone())
-        .with_optional_arg(Argument::subcommands())
+        .with_optional_arg(Argument::Subcommand)
         .with_subcommand(
+            // TODO: make this subcommand a normal command too
             Command::new()
             .with_name("back")
             .with_name("b")
@@ -81,7 +84,7 @@ pub(crate) fn command() -> Command {
                 .with_name("input")
                 .with_name("in")
                 .with_help(get_step_help_text(
-                        "Steps forwards until your program asks for its next input, or finishes.",
+                    "Steps forwards until your program asks for its next input, or finishes.",
                 ))
                 .with_exec(|_, helper, _| step_input(helper)),
             )
@@ -90,7 +93,7 @@ pub(crate) fn command() -> Command {
                 .with_name("output")
                 .with_name("out")
                 .with_name(get_step_help_text(
-                        "Steps forwards until your program asks for its next output, or finishes.",
+                    "Steps forwards until your program asks for its next output, or finishes.",
                 ))
                 .with_exec(|_, helper, _| step_output(helper)),
             )
@@ -108,8 +111,8 @@ pub(crate) fn command() -> Command {
                 Command::new()
                 .with_name("float")
                 .with_help(get_step_help_text(
-                        "Steps forwards until your program executes a syscall that requires\n\
-                        reading or writing a float, or finishes.",
+                    "Steps forwards until your program executes a syscall that requires\n\
+                    reading or writing a float, or finishes.",
                 ))
                 .with_exec(|_, helper, _| step_float(helper)),
             )
@@ -151,7 +154,7 @@ pub(crate) fn command() -> Command {
                 ))
                 .with_exec(|_, helper, _| step_file(helper)),
             )
-            .with_required_arg(Argument::subcommands())
+            .with_required_arg(Argument::Subcommand)
             .with_exec(call_subcmds)
         )
 }

--- a/crates/mipsy_interactive/src/interactive/commands/step.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/step.rs
@@ -8,23 +8,27 @@ use super::*;
 use colored::*;
 use mipsy_lib::Register;
 
+pub(super) fn args_numbers(args: &[ArgumentKind]) -> Vec<i64> {
+    args.iter().cloned().map(i64::from).collect()
+}
+
 fn call_subcmds(
     cmd: &Command,
     state: &mut State,
+    helper: &MyHelper,
     label: &str,
     args: &[ArgumentKind],
 ) -> CommandResult<String> {
     match args.get(0) {
-        Some(ArgumentKind::SubCommand(arg)) => {
+        Some(ArgumentKind::String(arg)) => {
             if let Some(cmd) = cmd.subcommands.iter().find(|c| c.names.contains(arg)) {
-                return (cmd._internal_exec)(cmd, state, label, &args[1..]);
+                return (cmd._internal_exec)(cmd, state, helper, label, &args[1..]);
             }
         }
         None | Some(ArgumentKind::Number(_)) => {}
-        _ => unreachable!(),
     }
 
-    step_syscall(state, label)
+    step_syscall(state, label, helper)
 }
 
 fn subcmd() -> Command {
@@ -36,46 +40,46 @@ fn subcmd() -> Command {
             Command::new()
                 .with_name("input")
                 .with_name("in")
-                .with_exec(|_, state, label, _| step_input(state, label)),
+                .with_exec(|_, state, helper, label, _| step_input(state, label, helper)),
         )
         .with_subcommand(
             Command::new()
                 .with_name("output")
                 .with_name("out")
-                .with_exec(|_, state, label, _| step_output(state, label)),
+                .with_exec(|_, state, helper, label, _| step_output(state, label, helper)),
         )
         .with_subcommand(
             Command::new()
                 .with_name("integer")
                 .with_name("int")
-                .with_exec(|_, state, label, _| step_integer(state, label)),
+                .with_exec(|_, state, helper, label, _| step_integer(state, label, helper)),
         )
         .with_subcommand(
             Command::new()
                 .with_name("float")
-                .with_exec(|_, state, label, _| step_float(state, label)),
+                .with_exec(|_, state, helper, label, _| step_float(state, label, helper)),
         )
         .with_subcommand(
             Command::new()
                 .with_name("double")
-                .with_exec(|_, state, label, _| step_double(state, label)),
+                .with_exec(|_, state, helper, label, _| step_double(state, label, helper)),
         )
         .with_subcommand(
             Command::new()
                 .with_name("string")
                 .with_name("str")
-                .with_exec(|_, state, label, _| step_string(state, label)),
+                .with_exec(|_, state, helper, label, _| step_string(state, label, helper)),
         )
         .with_subcommand(
             Command::new()
                 .with_name("character")
                 .with_name("char")
-                .with_exec(|_, state, label, _| step_character(state, label)),
+                .with_exec(|_, state, helper, label, _| step_character(state, label, helper)),
         )
         .with_subcommand(
             Command::new()
                 .with_name("file")
-                .with_exec(|_, state, label, _| step_file(state, label)),
+                .with_exec(|_, state, helper, label, _| step_file(state, label, helper)),
         )
         .with_exec(call_subcmds)
 }
@@ -83,7 +87,7 @@ fn subcmd() -> Command {
 pub(crate) fn command() -> Command {
     let times_arg = Argument::new(
         "times",
-        |a| match a.parse::<i32>() {
+        |a, _| match a.parse::<i32>() {
             Ok(i) => Ok(ArgumentKind::Number(i as _)),
             Err(_) => Err(CommandError::WithTip {
                 error: Box::new(CommandError::ArgExpectedI32 {
@@ -109,7 +113,9 @@ pub(crate) fn command() -> Command {
                 .with_name("back")
                 .with_name("b")
                 .with_optional_arg(times_arg)
-                .with_exec(|_, state, label, args| step_back(state, label, args)),
+                .with_exec(|_, state, helper, label, args| {
+                    step_back(state, label, &args_numbers(args), helper)
+                }),
         )
         .with_subcommand(subcmd())
         .with_exec(call_subcmds)
@@ -142,27 +148,26 @@ fn get_long_help() -> String {
 fn step_forward(
     state: &mut State,
     label: &str,
-    args: &[ArgumentKind],
+    args: &[i64],
+    helper: &MyHelper,
 ) -> Result<String, CommandError> {
-    let times = match args.first() {
-        Some(&ArgumentKind::Number(num)) => {
-            if num.is_negative() {
-                return step_back(
-                    state,
-                    label,
-                    [ArgumentKind::Number(num as _)]
-                        .into_iter()
-                        .chain(args.iter().skip(1).cloned())
-                        .collect::<Vec<_>>()
-                        .as_ref(),
-                );
-            }
-
-            num as _
-        }
-        None => 1,
-        _ => unreachable!(),
-    };
+    let times = args
+        .first()
+        .and_then(|&n| Some(i64::from(n)))
+        .or(Some(1))
+        .unwrap();
+    if times.is_negative() {
+        return step_back(
+            state,
+            label,
+            [times]
+                .into_iter()
+                .chain(args.iter().skip(1).cloned())
+                .collect::<Vec<_>>()
+                .as_ref(),
+            helper,
+        );
+    }
 
     if state.exited {
         return Err(CommandError::ProgramExited);
@@ -183,7 +188,7 @@ fn step_forward(
             );
         }
 
-        let step = state.step(true)?;
+        let step = state.step(true, helper)?;
 
         if step | state.interrupted.load(Ordering::SeqCst) {
             break;
@@ -193,7 +198,12 @@ fn step_forward(
     Ok("".into())
 }
 
-fn step_back(state: &mut State, label: &str, args: &[ArgumentKind]) -> CommandResult<String> {
+fn step_back(
+    state: &mut State,
+    label: &str,
+    args: &[i64],
+    helper: &MyHelper,
+) -> CommandResult<String> {
     if label == "__help__" {
         return Ok(format!(
             "Steps backwards one instruction, or {0} instructions if specified.\n\
@@ -205,25 +215,19 @@ fn step_back(state: &mut State, label: &str, args: &[ArgumentKind]) -> CommandRe
         ));
     }
 
-    let times = match args.first() {
-        Some(ArgumentKind::Number(num)) => {
-            if num.is_negative() {
-                return step_forward(
-                    state,
-                    label,
-                    [ArgumentKind::Number(num.abs())]
-                        .into_iter()
-                        .chain(args.iter().skip(1).cloned())
-                        .collect::<Vec<_>>()
-                        .as_ref(),
-                );
-            }
-
-            *num as _
-        }
-        None => 1,
-        _ => unreachable!(),
-    };
+    let times = *args.first().or(Some(&1)).unwrap();
+    if times.is_negative() {
+        return step_forward(
+            state,
+            label,
+            [times.abs()]
+                .into_iter()
+                .chain(args.iter().skip(1).cloned())
+                .collect::<Vec<_>>()
+                .as_ref(),
+            helper,
+        );
+    }
 
     let mut backs = 0;
     let mut ran_out_of_history = false;
@@ -285,7 +289,7 @@ fn step_back(state: &mut State, label: &str, args: &[ArgumentKind]) -> CommandRe
     Ok("".into())
 }
 
-fn step_syscall(state: &mut State, label: &str) -> Result<String, CommandError> {
+fn step_syscall(state: &mut State, label: &str, helper: &MyHelper) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(get_step_help_text(
             format!(
@@ -321,30 +325,38 @@ fn step_syscall(state: &mut State, label: &str) -> Result<String, CommandError> 
         ));
     }
 
-    step_till_condition(state, |_| true)
+    step_till_condition(state, |_| true, helper)
 }
 
-fn step_input(state: &mut State, label: &str) -> Result<String, CommandError> {
+fn step_input(state: &mut State, label: &str, helper: &MyHelper) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(get_step_help_text(
             "Steps forwards until your program asks for its next input, or finishes.",
         ));
     }
 
-    step_till_condition(state, |syscall| matches!(syscall, 5 | 6 | 7 | 8 | 12))
+    step_till_condition(
+        state,
+        |syscall| matches!(syscall, 5 | 6 | 7 | 8 | 12),
+        helper,
+    )
 }
 
-fn step_output(state: &mut State, label: &str) -> Result<String, CommandError> {
+fn step_output(state: &mut State, label: &str, helper: &MyHelper) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(get_step_help_text(
             "Steps forwards until your program asks for its next output, or finishes.",
         ));
     }
 
-    step_till_condition(state, |syscall| matches!(syscall, 1 | 2 | 3 | 4 | 11))
+    step_till_condition(
+        state,
+        |syscall| matches!(syscall, 1 | 2 | 3 | 4 | 11),
+        helper,
+    )
 }
 
-fn step_integer(state: &mut State, label: &str) -> Result<String, CommandError> {
+fn step_integer(state: &mut State, label: &str, helper: &MyHelper) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(get_step_help_text(
             "Steps forwards until your program executes a syscall that requires\n\
@@ -352,10 +364,10 @@ fn step_integer(state: &mut State, label: &str) -> Result<String, CommandError> 
         ));
     }
 
-    step_till_condition(state, |syscall| matches!(syscall, 1 | 5))
+    step_till_condition(state, |syscall| matches!(syscall, 1 | 5), helper)
 }
 
-fn step_float(state: &mut State, label: &str) -> Result<String, CommandError> {
+fn step_float(state: &mut State, label: &str, helper: &MyHelper) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(get_step_help_text(
             "Steps forwards until your program executes a syscall that requires\n\
@@ -363,10 +375,10 @@ fn step_float(state: &mut State, label: &str) -> Result<String, CommandError> {
         ));
     }
 
-    step_till_condition(state, |syscall| matches!(syscall, 2 | 6))
+    step_till_condition(state, |syscall| matches!(syscall, 2 | 6), helper)
 }
 
-fn step_double(state: &mut State, label: &str) -> Result<String, CommandError> {
+fn step_double(state: &mut State, label: &str, helper: &MyHelper) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(get_step_help_text(
             "Steps forwards until your program executes a syscall that requires\n\
@@ -374,10 +386,10 @@ fn step_double(state: &mut State, label: &str) -> Result<String, CommandError> {
         ));
     }
 
-    step_till_condition(state, |syscall| matches!(syscall, 3 | 7))
+    step_till_condition(state, |syscall| matches!(syscall, 3 | 7), helper)
 }
 
-fn step_string(state: &mut State, label: &str) -> Result<String, CommandError> {
+fn step_string(state: &mut State, label: &str, helper: &MyHelper) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(get_step_help_text(
             "Steps forwards until your program executes a syscall that requires\n\
@@ -385,10 +397,14 @@ fn step_string(state: &mut State, label: &str) -> Result<String, CommandError> {
         ));
     }
 
-    step_till_condition(state, |syscall| matches!(syscall, 4 | 8))
+    step_till_condition(state, |syscall| matches!(syscall, 4 | 8), helper)
 }
 
-fn step_character(state: &mut State, label: &str) -> Result<String, CommandError> {
+fn step_character(
+    state: &mut State,
+    label: &str,
+    helper: &MyHelper,
+) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(get_step_help_text(
             "Steps forwards until your program executes a syscall that requires\n\
@@ -396,10 +412,10 @@ fn step_character(state: &mut State, label: &str) -> Result<String, CommandError
         ));
     }
 
-    step_till_condition(state, |syscall| matches!(syscall, 11 | 12))
+    step_till_condition(state, |syscall| matches!(syscall, 11 | 12), helper)
 }
 
-fn step_file(state: &mut State, label: &str) -> Result<String, CommandError> {
+fn step_file(state: &mut State, label: &str, helper: &MyHelper) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(get_step_help_text(
             "Steps forwards until your program executes a syscall that opens,\n\
@@ -407,10 +423,18 @@ fn step_file(state: &mut State, label: &str) -> Result<String, CommandError> {
         ));
     }
 
-    step_till_condition(state, |syscall| matches!(syscall, 13 | 14 | 15 | 16))
+    step_till_condition(
+        state,
+        |syscall| matches!(syscall, 13 | 14 | 15 | 16),
+        helper,
+    )
 }
 
-fn step_till_condition<F>(state: &mut State, condition: F) -> Result<String, CommandError>
+fn step_till_condition<F>(
+    state: &mut State,
+    condition: F,
+    helper: &MyHelper,
+) -> Result<String, CommandError>
 where
     F: Fn(i32) -> bool,
 {
@@ -446,7 +470,7 @@ where
             false
         };
 
-        let step = state.step(true)?;
+        let step = state.step(true, helper)?;
 
         if step || stop {
             break;

--- a/crates/mipsy_interactive/src/interactive/commands/util.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/util.rs
@@ -16,8 +16,8 @@ where
     F: Fn(i32) -> String,
 {
     match arg.parse::<u32>() {
-        Ok(num) => Ok(num),
-        Err(_) => Err({
+        Ok(num) if num != 0 => Ok(num),
+        _ => Err({
             let err = CommandError::ArgExpectedU32 {
                 arg: name.to_string(),
                 instead: arg.to_string(),

--- a/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
@@ -29,7 +29,11 @@ enum MipsyArgType {
 }
 
 pub(crate) fn args_text(args: &[ArgumentKind]) -> Vec<String> {
-    args.iter().cloned().map(String::from).collect()
+    args.iter()
+        .cloned()
+        .map(String::try_from)
+        .map(Result::unwrap)
+        .collect()
 }
 
 pub(crate) fn command() -> Command {
@@ -39,7 +43,7 @@ pub(crate) fn command() -> Command {
         .with_name("wa")
         .with_name("wp")
         .with_name("watch")
-        .with_required_arg(Argument::subcommands())
+        .with_required_arg(Argument::Subcommand)
         .with_subcommand(
             Command::new()
                 .with_name("list")
@@ -165,7 +169,7 @@ pub(crate) fn command() -> Command {
             match cmd
                 .subcommands
                 .iter()
-                .find(|c| c.names.contains(&args[0].to_owned().into()))
+                .find(|c| c.names.contains(&args[0].to_owned().try_into().unwrap()))
                 {
                     Some(cmd) => (cmd._internal_exec)(cmd, helper, &args[1..]),
                     None => watchpoint_insert(&mut helper.state, &args_text(args), InsertOp::Insert),

--- a/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
@@ -56,6 +56,7 @@ pub(crate) fn command() -> Command {
                 .with_name("in")
                 .with_name("ins")
                 .with_name("add")
+                .with_required_arg(Argument::from_name("target"))
                 .with_help(watchpoint_insert_help())
                 .with_exec(|_, helper, args| {
                     watchpoint_insert(&mut helper.state, &args_text(args), InsertOp::Insert)
@@ -177,20 +178,6 @@ fn watchpoint_insert(
     args: &[String],
     op: InsertOp,
 ) -> Result<String, CommandError> {
-    if args.is_empty() {
-        return Err(generate_err(
-            CommandError::MissingArguments {
-                args: vec!["target".to_string()],
-                instead: vec![],
-            },
-            match op {
-                InsertOp::Insert => "insert",
-                InsertOp::Delete => "delete",
-                InsertOp::Temporary => "temporary",
-            },
-        ));
-    }
-
     let (target, arg_type) = parse_watchpoint_arg(state, &args[0])?;
     let binary = state.binary.as_mut().ok_or(CommandError::MustLoadFile)?;
 

--- a/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
@@ -44,9 +44,7 @@ pub(crate) fn command() -> Command {
         .with_name("wa")
         .with_name("wp")
         .with_name("watch")
-        .with_optional_arg(Argument::new("subcommand", |a| {
-            Ok(ArgumentKind::SubCommand(a.to_owned()))
-        }))
+        .with_optional_arg(Argument::subcommands())
         .with_subcommand(
             Command::new()
                 .with_name("list")

--- a/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
@@ -44,7 +44,10 @@ pub(crate) fn command() -> Command {
             Command::new()
                 .with_name("list")
                 .with_name("l")
-                .with_exec(|_, state, _, label, _| watchpoint_list(state, label)),
+                .with_help(
+"Lists currently set watchpoints.".to_string()
+                )
+                .with_exec(|_, state, _, _| watchpoint_list(state)),
         )
         .with_subcommand(
             Command::new()
@@ -53,8 +56,9 @@ pub(crate) fn command() -> Command {
                 .with_name("in")
                 .with_name("ins")
                 .with_name("add")
-                .with_exec(|_, state, _, label, args| {
-                    watchpoint_insert(state, label, &args_text(args), InsertOp::Insert)
+                .with_help(watchpoint_insert_help())
+                .with_exec(|_, state, _, args| {
+                    watchpoint_insert(state, &args_text(args), InsertOp::Insert)
                 }),
         )
         .with_subcommand(
@@ -64,8 +68,9 @@ pub(crate) fn command() -> Command {
                 .with_name("delete")
                 .with_name("r")
                 .with_name("rm")
-                .with_exec(|_, state, _, label, args| {
-                    watchpoint_insert(state, label, &args_text(args), InsertOp::Delete)
+                .with_help(watchpoint_insert_help())
+                .with_exec(|_, state, _, args| {
+                    watchpoint_insert(state, &args_text(args), InsertOp::Delete)
                 }),
         )
         .with_subcommand(
@@ -73,30 +78,54 @@ pub(crate) fn command() -> Command {
                 .with_name("temporary")
                 .with_name("temp")
                 .with_name("tmp")
-                .with_exec(|_, state, _, label, args| {
-                    watchpoint_insert(state, label, &args_text(args), InsertOp::Temporary)
+                .with_help(watchpoint_insert_help())
+                .with_exec(|_, state, _, args| {
+                    watchpoint_insert(state, &args_text(args), InsertOp::Temporary)
                 }),
         )
-        .with_subcommand(Command::new().with_name("enable").with_name("e").with_exec(
-            |_, state, _, label, args| {
-                watchpoint_toggle(state, label, &args_text(args), WpState::Enable)
+        .with_subcommand(Command::new().with_name("enable").with_name("e")
+            .with_help(watchpoint_toggle_help())
+            .with_exec(
+            |_, state, _, args| {
+                watchpoint_toggle(state, &args_text(args), WpState::Enable)
             },
         ))
         .with_subcommand(
             Command::new()
                 .with_name("disable")
                 .with_name("d")
-                .with_exec(|_, state, _, label, args| {
-                    watchpoint_toggle(state, label, &args_text(args), WpState::Disable)
+                .with_help(watchpoint_toggle_help())
+                .with_exec(|_, state, _, args| {
+                    watchpoint_toggle(state, &args_text(args), WpState::Disable)
                 }),
         )
-        .with_subcommand(Command::new().with_name("toggle").with_name("t").with_exec(
-            |_, state, _, label, args| {
-                watchpoint_toggle(state, label, &args_text(args), WpState::Toggle)
+        .with_subcommand(Command::new().with_name("toggle").with_name("t")
+            .with_help(watchpoint_toggle_help())
+            .with_exec(
+            |_, state, _, args| {
+                watchpoint_toggle(state, &args_text(args), WpState::Toggle)
             },
         ))
-        .with_subcommand(Command::new().with_name("ignore").with_exec(
-            |_, state, _, label, args| watchpoint_ignore(state, label, &args_text(args)),
+        .with_subcommand(Command::new().with_name("ignore")
+            .with_help(
+            format!(
+                "Usage: {3} {4} {1} {0}\n\
+                 {4}s a watchpoint at the specified {1} for the next {0} hits.\n\
+                 {1} may be: a register name (`$t0`, `t0`), a register number (`$14`, 14), or an id (`{2}`).\n\
+                 a decimal address (`4194304`), a hex address (`{5}400000`), or a label (`{6}`).\n\
+                 watchpoints that are ignored do not trigger when they are hit.\n\
+                ",
+                "<ignore count>".purple(),
+                "<target>".purple(),
+                "!3".blue(),
+                "watchpoint".yellow().bold(),
+                "ignore".purple(),
+                "0x".yellow(),
+                "main".yellow().bold(),
+            )
+            )
+            .with_exec(
+            |_, state, _, args| watchpoint_ignore(state, &args_text(args)),
         ))
         .with_subcommand(
             Command::new()
@@ -106,100 +135,48 @@ pub(crate) fn command() -> Command {
                 .with_name("cmd")
                 .with_name("cmds")
                 .with_name("command")
-                .with_exec(|_, state, _, label, args| {
-                    watchpoint_commands(state, label, &args_text(args))
+                .with_help(
+format!(
+            "Takes in a list of commands seperated by newlines,\n\
+                 and attaches the commands to the specified {0}.\n\
+                 If no watchpoint is specified, the most recently created watchpoint is chosen.\n\
+                 Whenever that watchpoint is hit, the commands will automatically be executed\n\
+                 in the provided order.\n\
+                 The list of commands can be ended using the {1} command, EOF, or an empty line.\n\
+                 To view the commands attached to a particular watchpoint,\n\
+                 use {2} {0}
+                ",
+            "<watchpoint id>".purple(),
+            "end".yellow().bold(),
+            "commands list".bold().yellow(),
+        )
+                )
+                .with_exec(|_, state, _, args| {
+                    watchpoint_commands(state, &args_text(args))
                 }),
         )
         .with_desc(format!(
             "manage watchpoints ({} to list subcommands)",
             "help watchpoint".bold()
         ))
-        .with_exec(|cmd, state, helper, label, args| {
-            if label == "__help__" || args.is_empty() {
-                return Ok(get_long_help());
-            }
-
+        .with_help(get_long_help())
+        .with_exec(|cmd, state, helper, args| {
             match cmd
                 .subcommands
                 .iter()
                 .find(|c| c.names.contains(&args[0].to_owned().into()))
             {
-                None if label == "__help__" => Ok(get_long_help()),
-                Some(cmd) => (cmd._internal_exec)(cmd, state, helper, label, &args[1..]),
-                None => watchpoint_insert(state, label, &args_text(args), InsertOp::Insert),
+                Some(cmd) => (cmd._internal_exec)(cmd, state, helper, &args[1..]),
+                None => watchpoint_insert(state, &args_text(args), InsertOp::Insert),
             }
         })
 }
 
-fn get_long_help() -> String {
-    format!(
-        "A collection of commands for managing watchpoints. Available {10}s are:\n\n\
-         {0} {2}    : insert/delete a watchpoint\n\
-         {1} {3}\n\
-         {0} {12} : insert a temporary watchpoint that deletes itself after being hit\n\
-         {0} {13}  : attach commands to a watchpoint\n\
-         {0} {5}    : enable/disable an existing watchpoint\n\
-         {1} {6}\n\
-         {1} {7}\n\
-         {0} {11}    : ignore a watchpoint for a specified number of hits\n\
-         {0} {4}      : list currently set watchpoints\n\n\
-         {8} {9} will provide more information about the specified subcommand.
-        ",
-        "watchpoint".yellow().bold(),
-        "          ".yellow().bold(),
-        "insert".purple(),
-        "delete".purple(),
-        "list".purple(),
-        "enable".purple(),
-        "disable".purple(),
-        "toggle".purple(),
-        "help watchpoint".bold(),
-        "<subcommand>".purple().bold(),
-        "<subcommand>".purple(),
-        "ignore".purple(),
-        "temporary".purple(),
-        "commands".purple(),
-    )
-}
-
 fn watchpoint_insert(
     state: &mut State,
-    label: &str,
     args: &[String],
     op: InsertOp,
 ) -> Result<String, CommandError> {
-    if label == "__help__" {
-        return Ok(
-            format!(
-                "Usage: {5} {6} {2} {7}\n\
-                 {0}s or {1}s a watchpoint at the specified {2}.\n\
-                 {2} may be: a register name (`$t0`, `t0`), a register number (`$14`, `14`),\n\
-                 a decimal address (`4194304`), a hex address (`{8}400000`), or a label (`{9}`).\n\
-                 If you are removing a watchpoint, you can also use its id (`{3}`).\n\
-                 {4} must be `i`, `in`, `ins`, `insert`, or `add` to insert the watchpoint, or\n\
-            \x20             `del`, `delete`, `rm` or `remove` to remove the watchpoint.\n\
-                 If {10}, `tmp`, or `temp` is provided as the {4}, the watchpoint will\n\
-                 be created as a temporary watchpoint, which automatically deletes itself after being hit.\n\
-                 If {4} is none of these option, it defaults to inserting a watchpoint at {4}.\n\
-                 When running or stepping through your program, a watchpoint will cause execution to\n\
-                 pause temporarily when the specified register is read from or written to,\n\
-                 allowing you to debug the current state.\n\
-                 May error if provided a {2} that doesn't exist.",
-                "<insert>".magenta(),
-                "<delete>".magenta(),
-                "<target>".magenta(),
-                "!3".blue(),
-                "<subcommand>".magenta(),
-                "watchpoint".yellow().bold(),
-                "{insert, delete, temporary}".purple(),
-                "{read, write, read/write}".purple(),
-                "0x".yellow(),
-                "main".yellow().bold(),
-                "<temporary>".purple(),
-            )
-        );
-    }
-
     if args.is_empty() {
         return Err(generate_err(
             CommandError::MissingArguments {
@@ -318,11 +295,7 @@ fn watchpoint_insert(
     Ok("".into())
 }
 
-fn watchpoint_list(state: &State, label: &str) -> Result<String, CommandError> {
-    if label == "__help__" {
-        return Ok("Lists currently set watchpoints.".to_string());
-    }
-
+fn watchpoint_list(state: &State) -> Result<String, CommandError> {
     let binary = state.binary.as_ref().ok_or(CommandError::MustLoadFile)?;
 
     if binary.watchpoints.is_empty() {
@@ -400,31 +373,9 @@ fn watchpoint_list(state: &State, label: &str) -> Result<String, CommandError> {
 
 fn watchpoint_toggle(
     state: &mut State,
-    label: &str,
     args: &[String],
     op: WpState,
 ) -> Result<String, CommandError> {
-    if label == "__help__" {
-        return Ok(
-            format!(
-                "Usage: {5} {6} {3}\n\
-                 {0}s, {1}s, or {2}s a watchpoint at the specified {3}.\n\
-                 {3} may be: a register name (`$t0`, `t0`), a register number (`$14`, 14), or an id (`{4}`).\n\
-                 a decimal address (`4194304`), a hex address (`{7}400000`), or a label (`{8}`).\n\
-                 watchpoints that are disabled do not trigger when they are hit.",
-                "<enable>".purple(),
-                "<disable>".purple(),
-                "<toggle>".purple(),
-                "<target>".purple(),
-                "!3".blue(),
-                "watchpoint".yellow().bold(),
-                "{enable, disable, toggle}".purple(),
-                "0x".yellow(),
-                "main".yellow().bold(),
-            )
-        );
-    }
-
     if args.is_empty() {
         return Err(generate_err(
             CommandError::MissingArguments {
@@ -499,31 +450,7 @@ fn watchpoint_toggle(
     Ok("".into())
 }
 
-fn watchpoint_ignore(
-    state: &mut State,
-    label: &str,
-    args: &[String],
-) -> Result<String, CommandError> {
-    if label == "__help__" {
-        return Ok(
-            format!(
-                "Usage: {3} {4} {1} {0}\n\
-                 {4}s a watchpoint at the specified {1} for the next {0} hits.\n\
-                 {1} may be: a register name (`$t0`, `t0`), a register number (`$14`, 14), or an id (`{2}`).\n\
-                 a decimal address (`4194304`), a hex address (`{5}400000`), or a label (`{6}`).\n\
-                 watchpoints that are ignored do not trigger when they are hit.\n\
-                ",
-                "<ignore count>".purple(),
-                "<target>".purple(),
-                "!3".blue(),
-                "watchpoint".yellow().bold(),
-                "ignore".purple(),
-                "0x".yellow(),
-                "main".yellow().bold(),
-            )
-        );
-    }
-
+fn watchpoint_ignore(state: &mut State, args: &[String]) -> Result<String, CommandError> {
     if args.is_empty() {
         return Err(generate_err(
             CommandError::MissingArguments {
@@ -579,28 +506,7 @@ fn watchpoint_ignore(
     Ok("".into())
 }
 
-fn watchpoint_commands(
-    state: &mut State,
-    label: &str,
-    args: &[String],
-) -> Result<String, CommandError> {
-    if label == "__help__" {
-        return Ok(format!(
-            "Takes in a list of commands seperated by newlines,\n\
-                 and attaches the commands to the specified {0}.\n\
-                 If no watchpoint is specified, the most recently created watchpoint is chosen.\n\
-                 Whenever that watchpoint is hit, the commands will automatically be executed\n\
-                 in the provided order.\n\
-                 The list of commands can be ended using the {1} command, EOF, or an empty line.\n\
-                 To view the commands attached to a particular watchpoint,\n\
-                 use {2} {0}
-                ",
-            "<watchpoint id>".purple(),
-            "end".yellow().bold(),
-            "commands list".bold().yellow(),
-        ));
-    }
-
+fn watchpoint_commands(state: &mut State, args: &[String]) -> Result<String, CommandError> {
     let binary = state.binary.as_mut().ok_or(CommandError::MustLoadFile)?;
     state.confirm_exit = true;
     handle_commands(&args, &mut binary.watchpoints)
@@ -676,4 +582,84 @@ fn parse_watchpoint_arg(
     };
 
     Ok((target, MipsyArgType::Target))
+}
+
+fn get_long_help() -> String {
+    format!(
+        "A collection of commands for managing watchpoints. Available {10}s are:\n\n\
+         {0} {2}    : insert/delete a watchpoint\n\
+         {1} {3}\n\
+         {0} {12} : insert a temporary watchpoint that deletes itself after being hit\n\
+         {0} {13}  : attach commands to a watchpoint\n\
+         {0} {5}    : enable/disable an existing watchpoint\n\
+         {1} {6}\n\
+         {1} {7}\n\
+         {0} {11}    : ignore a watchpoint for a specified number of hits\n\
+         {0} {4}      : list currently set watchpoints\n\n\
+         {8} {9} will provide more information about the specified subcommand.
+        ",
+        "watchpoint".yellow().bold(),
+        "          ".yellow().bold(),
+        "insert".purple(),
+        "delete".purple(),
+        "list".purple(),
+        "enable".purple(),
+        "disable".purple(),
+        "toggle".purple(),
+        "help watchpoint".bold(),
+        "<subcommand>".purple().bold(),
+        "<subcommand>".purple(),
+        "ignore".purple(),
+        "temporary".purple(),
+        "commands".purple(),
+    )
+}
+
+fn watchpoint_insert_help() -> String {
+    format!(
+        "Usage: {5} {6} {2} {7}\n\
+         {0}s or {1}s a watchpoint at the specified {2}.\n\
+         {2} may be: a register name (`$t0`, `t0`), a register number (`$14`, `14`),\n\
+         a decimal address (`4194304`), a hex address (`{8}400000`), or a label (`{9}`).\n\
+         If you are removing a watchpoint, you can also use its id (`{3}`).\n\
+         {4} must be `i`, `in`, `ins`, `insert`, or `add` to insert the watchpoint, or\n\
+                     `del`, `delete`, `rm` or `remove` to remove the watchpoint.\n\
+         If {10}, `tmp`, or `temp` is provided as the {4}, the watchpoint will\n\
+         be created as a temporary watchpoint, which automatically deletes itself after being hit.\n\
+         If {4} is none of these option, it defaults to inserting a watchpoint at {4}.\n\
+         When running or stepping through your program, a watchpoint will cause execution to\n\
+         pause temporarily when the specified register is read from or written to,\n\
+         allowing you to debug the current state.\n\
+         May error if provided a {2} that doesn't exist.",
+        "<insert>".magenta(),
+        "<delete>".magenta(),
+        "<target>".magenta(),
+        "!3".blue(),
+        "<subcommand>".magenta(),
+        "watchpoint".yellow().bold(),
+        "{insert, delete, temporary}".purple(),
+        "{read, write, read/write}".purple(),
+        "0x".yellow(),
+        "main".yellow().bold(),
+        "<temporary>".purple(),
+        )
+}
+
+fn watchpoint_toggle_help() -> String {
+    format!(
+        "Usage: {5} {6} {3}\n\
+         {0}s, {1}s, or {2}s a watchpoint at the specified {3}.\n\
+         {3} may be: a register name (`$t0`, `t0`), a register number (`$14`, 14), or an id (`{4}`).\n\
+         a decimal address (`4194304`), a hex address (`{7}400000`), or a label (`{8}`).\n\
+         watchpoints that are disabled do not trigger when they are hit.",
+        "<enable>".purple(),
+        "<disable>".purple(),
+        "<toggle>".purple(),
+        "<target>".purple(),
+        "!3".blue(),
+        "watchpoint".yellow().bold(),
+        "{enable, disable, toggle}".purple(),
+        "0x".yellow(),
+        "main".yellow().bold(),
+    )
 }

--- a/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
@@ -39,13 +39,13 @@ pub(crate) fn command() -> Command {
         .with_name("wa")
         .with_name("wp")
         .with_name("watch")
-        .with_optional_arg(Argument::subcommands())
+        .with_required_arg(Argument::subcommands())
         .with_subcommand(
             Command::new()
                 .with_name("list")
                 .with_name("l")
                 .with_help(
-"Lists currently set watchpoints.".to_string()
+                    "Lists currently set watchpoints.".to_string()
                 )
                 .with_exec(|_, helper, _| watchpoint_list(&helper.state)),
         )

--- a/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
@@ -136,28 +136,28 @@ pub(crate) fn command() -> Command {
                 .with_name("cmds")
                 .with_name("command")
                 .with_help(
-format!(
-            "Takes in a list of commands seperated by newlines,\n\
-                 and attaches the commands to the specified {0}.\n\
-                 If no watchpoint is specified, the most recently created watchpoint is chosen.\n\
-                 Whenever that watchpoint is hit, the commands will automatically be executed\n\
-                 in the provided order.\n\
-                 The list of commands can be ended using the {1} command, EOF, or an empty line.\n\
-                 To view the commands attached to a particular watchpoint,\n\
-                 use {2} {0}
-                ",
-            "<watchpoint id>".purple(),
-            "end".yellow().bold(),
-            "commands list".bold().yellow(),
-        )
+                    format!(
+                        "Takes in a list of commands seperated by newlines,\n\
+                        and attaches the commands to the specified {0}.\n\
+                        If no watchpoint is specified, the most recently created watchpoint is chosen.\n\
+                        Whenever that watchpoint is hit, the commands will automatically be executed\n\
+                        in the provided order.\n\
+                        The list of commands can be ended using the {1} command, EOF, or an empty line.\n\
+                        To view the commands attached to a particular watchpoint,\n\
+                        use {2} {0}
+                        ",
+                        "<watchpoint id>".purple(),
+                        "end".yellow().bold(),
+                        "commands list".bold().yellow(),
+                    )
                 )
                 .with_exec(|_, state, _, args| {
                     watchpoint_commands(state, &args_text(args))
                 }),
-        )
+    )
         .with_desc(format!(
-            "manage watchpoints ({} to list subcommands)",
-            "help watchpoint".bold()
+                "manage watchpoints ({} to list subcommands)",
+                "help watchpoint".bold()
         ))
         .with_help(get_long_help())
         .with_exec(|cmd, state, helper, args| {
@@ -165,10 +165,10 @@ format!(
                 .subcommands
                 .iter()
                 .find(|c| c.names.contains(&args[0].to_owned().into()))
-            {
-                Some(cmd) => (cmd._internal_exec)(cmd, state, helper, &args[1..]),
-                None => watchpoint_insert(state, &args_text(args), InsertOp::Insert),
-            }
+                {
+                    Some(cmd) => (cmd._internal_exec)(cmd, state, helper, &args[1..]),
+                    None => watchpoint_insert(state, &args_text(args), InsertOp::Insert),
+                }
         })
 }
 
@@ -587,16 +587,16 @@ fn parse_watchpoint_arg(
 fn get_long_help() -> String {
     format!(
         "A collection of commands for managing watchpoints. Available {10}s are:\n\n\
-         {0} {2}    : insert/delete a watchpoint\n\
-         {1} {3}\n\
-         {0} {12} : insert a temporary watchpoint that deletes itself after being hit\n\
-         {0} {13}  : attach commands to a watchpoint\n\
-         {0} {5}    : enable/disable an existing watchpoint\n\
-         {1} {6}\n\
-         {1} {7}\n\
-         {0} {11}    : ignore a watchpoint for a specified number of hits\n\
-         {0} {4}      : list currently set watchpoints\n\n\
-         {8} {9} will provide more information about the specified subcommand.
+        {0} {2}    : insert/delete a watchpoint\n\
+        {1} {3}\n\
+        {0} {12} : insert a temporary watchpoint that deletes itself after being hit\n\
+        {0} {13}  : attach commands to a watchpoint\n\
+        {0} {5}    : enable/disable an existing watchpoint\n\
+        {1} {6}\n\
+        {1} {7}\n\
+        {0} {11}    : ignore a watchpoint for a specified number of hits\n\
+        {0} {4}      : list currently set watchpoints\n\n\
+        {8} {9} will provide more information about the specified subcommand.
         ",
         "watchpoint".yellow().bold(),
         "          ".yellow().bold(),
@@ -618,19 +618,19 @@ fn get_long_help() -> String {
 fn watchpoint_insert_help() -> String {
     format!(
         "Usage: {5} {6} {2} {7}\n\
-         {0}s or {1}s a watchpoint at the specified {2}.\n\
-         {2} may be: a register name (`$t0`, `t0`), a register number (`$14`, `14`),\n\
-         a decimal address (`4194304`), a hex address (`{8}400000`), or a label (`{9}`).\n\
-         If you are removing a watchpoint, you can also use its id (`{3}`).\n\
-         {4} must be `i`, `in`, `ins`, `insert`, or `add` to insert the watchpoint, or\n\
-                     `del`, `delete`, `rm` or `remove` to remove the watchpoint.\n\
-         If {10}, `tmp`, or `temp` is provided as the {4}, the watchpoint will\n\
-         be created as a temporary watchpoint, which automatically deletes itself after being hit.\n\
-         If {4} is none of these option, it defaults to inserting a watchpoint at {4}.\n\
-         When running or stepping through your program, a watchpoint will cause execution to\n\
-         pause temporarily when the specified register is read from or written to,\n\
-         allowing you to debug the current state.\n\
-         May error if provided a {2} that doesn't exist.",
+        {0}s or {1}s a watchpoint at the specified {2}.\n\
+        {2} may be: a register name (`$t0`, `t0`), a register number (`$14`, `14`),\n\
+        a decimal address (`4194304`), a hex address (`{8}400000`), or a label (`{9}`).\n\
+        If you are removing a watchpoint, you can also use its id (`{3}`).\n\
+        {4} must be `i`, `in`, `ins`, `insert`, or `add` to insert the watchpoint, or\n\
+        `del`, `delete`, `rm` or `remove` to remove the watchpoint.\n\
+        If {10}, `tmp`, or `temp` is provided as the {4}, the watchpoint will\n\
+        be created as a temporary watchpoint, which automatically deletes itself after being hit.\n\
+        If {4} is none of these option, it defaults to inserting a watchpoint at {4}.\n\
+        When running or stepping through your program, a watchpoint will cause execution to\n\
+        pause temporarily when the specified register is read from or written to,\n\
+        allowing you to debug the current state.\n\
+        May error if provided a {2} that doesn't exist.",
         "<insert>".magenta(),
         "<delete>".magenta(),
         "<target>".magenta(),
@@ -642,16 +642,16 @@ fn watchpoint_insert_help() -> String {
         "0x".yellow(),
         "main".yellow().bold(),
         "<temporary>".purple(),
-        )
+    )
 }
 
 fn watchpoint_toggle_help() -> String {
     format!(
         "Usage: {5} {6} {3}\n\
-         {0}s, {1}s, or {2}s a watchpoint at the specified {3}.\n\
-         {3} may be: a register name (`$t0`, `t0`), a register number (`$14`, 14), or an id (`{4}`).\n\
-         a decimal address (`4194304`), a hex address (`{7}400000`), or a label (`{8}`).\n\
-         watchpoints that are disabled do not trigger when they are hit.",
+        {0}s, {1}s, or {2}s a watchpoint at the specified {3}.\n\
+        {3} may be: a register name (`$t0`, `t0`), a register number (`$14`, 14), or an id (`{4}`).\n\
+        a decimal address (`4194304`), a hex address (`{7}400000`), or a label (`{8}`).\n\
+        watchpoints that are disabled do not trigger when they are hit.",
         "<enable>".purple(),
         "<disable>".purple(),
         "<toggle>".purple(),

--- a/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
@@ -28,13 +28,8 @@ enum MipsyArgType {
     Id,
 }
 
-pub(super) fn args_text(args: &[ArgumentKind]) -> Vec<&String> {
-    args.iter()
-        .map(|a| match a {
-            ArgumentKind::Any(a) => a,
-            _ => unreachable!(),
-        })
-        .collect()
+pub(crate) fn args_text(args: &[ArgumentKind]) -> Vec<String> {
+    args.iter().cloned().map(String::from).collect()
 }
 
 pub(crate) fn command() -> Command {
@@ -49,7 +44,7 @@ pub(crate) fn command() -> Command {
             Command::new()
                 .with_name("list")
                 .with_name("l")
-                .with_exec(|_, state, label, _| watchpoint_list(state, label)),
+                .with_exec(|_, state, _, label, _| watchpoint_list(state, label)),
         )
         .with_subcommand(
             Command::new()
@@ -58,8 +53,8 @@ pub(crate) fn command() -> Command {
                 .with_name("in")
                 .with_name("ins")
                 .with_name("add")
-                .with_exec(|_, state, label, args| {
-                    watchpoint_insert(state, label, args, InsertOp::Insert)
+                .with_exec(|_, state, _, label, args| {
+                    watchpoint_insert(state, label, &args_text(args), InsertOp::Insert)
                 }),
         )
         .with_subcommand(
@@ -69,8 +64,8 @@ pub(crate) fn command() -> Command {
                 .with_name("delete")
                 .with_name("r")
                 .with_name("rm")
-                .with_exec(|_, state, label, args| {
-                    watchpoint_insert(state, label, args, InsertOp::Delete)
+                .with_exec(|_, state, _, label, args| {
+                    watchpoint_insert(state, label, &args_text(args), InsertOp::Delete)
                 }),
         )
         .with_subcommand(
@@ -78,29 +73,31 @@ pub(crate) fn command() -> Command {
                 .with_name("temporary")
                 .with_name("temp")
                 .with_name("tmp")
-                .with_exec(|_, state, label, args| {
-                    watchpoint_insert(state, label, args, InsertOp::Temporary)
+                .with_exec(|_, state, _, label, args| {
+                    watchpoint_insert(state, label, &args_text(args), InsertOp::Temporary)
                 }),
         )
         .with_subcommand(Command::new().with_name("enable").with_name("e").with_exec(
-            |_, state, label, args| watchpoint_toggle(state, label, args, WpState::Enable),
+            |_, state, _, label, args| {
+                watchpoint_toggle(state, label, &args_text(args), WpState::Enable)
+            },
         ))
         .with_subcommand(
             Command::new()
                 .with_name("disable")
                 .with_name("d")
-                .with_exec(|_, state, label, args| {
-                    watchpoint_toggle(state, label, args, WpState::Disable)
+                .with_exec(|_, state, _, label, args| {
+                    watchpoint_toggle(state, label, &args_text(args), WpState::Disable)
                 }),
         )
         .with_subcommand(Command::new().with_name("toggle").with_name("t").with_exec(
-            |_, state, label, args| watchpoint_toggle(state, label, args, WpState::Toggle),
+            |_, state, _, label, args| {
+                watchpoint_toggle(state, label, &args_text(args), WpState::Toggle)
+            },
         ))
-        .with_subcommand(
-            Command::new()
-                .with_name("ignore")
-                .with_exec(|_, state, label, args| watchpoint_ignore(state, label, args)),
-        )
+        .with_subcommand(Command::new().with_name("ignore").with_exec(
+            |_, state, _, label, args| watchpoint_ignore(state, label, &args_text(args)),
+        ))
         .with_subcommand(
             Command::new()
                 .with_name("commands")
@@ -109,25 +106,27 @@ pub(crate) fn command() -> Command {
                 .with_name("cmd")
                 .with_name("cmds")
                 .with_name("command")
-                .with_exec(|_, state, label, args| watchpoint_commands(state, label, args)),
+                .with_exec(|_, state, _, label, args| {
+                    watchpoint_commands(state, label, &args_text(args))
+                }),
         )
         .with_desc(format!(
             "manage watchpoints ({} to list subcommands)",
             "help watchpoint".bold()
         ))
-        .with_exec(|cmd, state, label, args| {
+        .with_exec(|cmd, state, helper, label, args| {
             if label == "__help__" || args.is_empty() {
                 return Ok(get_long_help());
             }
 
-            match if let ArgumentKind::SubCommand(arg) = &args[0] {
-                cmd.subcommands.iter().find(|c| c.names.contains(&arg))
-            } else {
-                None
-            } {
+            match cmd
+                .subcommands
+                .iter()
+                .find(|c| c.names.contains(&args[0].to_owned().into()))
+            {
                 None if label == "__help__" => Ok(get_long_help()),
-                Some(cmd) => (cmd._internal_exec)(cmd, state, label, &args[1..]),
-                None => watchpoint_insert(state, label, args, InsertOp::Insert),
+                Some(cmd) => (cmd._internal_exec)(cmd, state, helper, label, &args[1..]),
+                None => watchpoint_insert(state, label, &args_text(args), InsertOp::Insert),
             }
         })
 }
@@ -166,7 +165,7 @@ fn get_long_help() -> String {
 fn watchpoint_insert(
     state: &mut State,
     label: &str,
-    args: &[ArgumentKind],
+    args: &[String],
     op: InsertOp,
 ) -> Result<String, CommandError> {
     if label == "__help__" {
@@ -215,8 +214,7 @@ fn watchpoint_insert(
         ));
     }
 
-    let args = args_text(args);
-    let (target, arg_type) = parse_watchpoint_arg(state, args[0])?;
+    let (target, arg_type) = parse_watchpoint_arg(state, &args[0])?;
     let binary = state.binary.as_mut().ok_or(CommandError::MustLoadFile)?;
 
     let id;
@@ -243,7 +241,7 @@ fn watchpoint_insert(
             return Err(generate_err(
                 CommandError::MissingArguments {
                     args: vec!["action".to_string()],
-                    instead: args.iter().map(|&s| s.clone()).collect(),
+                    instead: args.to_vec(),
                 },
                 "rm",
             ));
@@ -283,7 +281,7 @@ fn watchpoint_insert(
 
     let label = match arg_type {
         MipsyArgType::Target => None,
-        MipsyArgType::Label => Some(args[0]),
+        MipsyArgType::Label => Some(&args[0]),
         MipsyArgType::Id => match target {
             WatchpointTarget::Register(_) => None,
             WatchpointTarget::MemAddr(addr) => binary
@@ -403,7 +401,7 @@ fn watchpoint_list(state: &State, label: &str) -> Result<String, CommandError> {
 fn watchpoint_toggle(
     state: &mut State,
     label: &str,
-    args: &[ArgumentKind],
+    args: &[String],
     op: WpState,
 ) -> Result<String, CommandError> {
     if label == "__help__" {
@@ -441,8 +439,7 @@ fn watchpoint_toggle(
         ));
     }
 
-    let args = args_text(args);
-    let (target, arg_type) = parse_watchpoint_arg(state, args[0])?;
+    let (target, arg_type) = parse_watchpoint_arg(state, &args[0])?;
 
     let binary = state.binary.as_mut().ok_or(CommandError::MustLoadFile)?;
 
@@ -474,7 +471,7 @@ fn watchpoint_toggle(
 
     let label = match arg_type {
         MipsyArgType::Target => None,
-        MipsyArgType::Label => Some(args[0]),
+        MipsyArgType::Label => Some(&args[0]),
         MipsyArgType::Id => match target {
             WatchpointTarget::Register(_) => None,
             WatchpointTarget::MemAddr(addr) => binary
@@ -505,7 +502,7 @@ fn watchpoint_toggle(
 fn watchpoint_ignore(
     state: &mut State,
     label: &str,
-    args: &[ArgumentKind],
+    args: &[String],
 ) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(
@@ -537,15 +534,14 @@ fn watchpoint_ignore(
         ));
     }
 
-    let args = args_text(args);
-    let (target, arg_type) = parse_watchpoint_arg(state, args[0])?;
+    let (target, arg_type) = parse_watchpoint_arg(state, &args[0])?;
 
     let args = &args[1..];
     if args.is_empty() {
         return Err(generate_err(
             CommandError::MissingArguments {
                 args: vec!["ignore count".to_string()],
-                instead: args.iter().map(|&s| s.clone()).collect(),
+                instead: args.to_vec(),
             },
             "ignore",
         ));
@@ -586,7 +582,7 @@ fn watchpoint_ignore(
 fn watchpoint_commands(
     state: &mut State,
     label: &str,
-    args: &[ArgumentKind],
+    args: &[String],
 ) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(format!(
@@ -607,14 +603,7 @@ fn watchpoint_commands(
 
     let binary = state.binary.as_mut().ok_or(CommandError::MustLoadFile)?;
     state.confirm_exit = true;
-    handle_commands(
-        args_text(args)
-            .into_iter()
-            .map(String::clone)
-            .collect::<Vec<_>>()
-            .as_slice(),
-        &mut binary.watchpoints,
-    )
+    handle_commands(&args, &mut binary.watchpoints)
 }
 
 fn generate_err(error: CommandError, command_name: impl Into<String>) -> CommandError {

--- a/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
@@ -47,7 +47,7 @@ pub(crate) fn command() -> Command {
                 .with_help(
 "Lists currently set watchpoints.".to_string()
                 )
-                .with_exec(|_, state, _, _| watchpoint_list(state)),
+                .with_exec(|_, helper, _| watchpoint_list(&helper.state)),
         )
         .with_subcommand(
             Command::new()
@@ -57,8 +57,8 @@ pub(crate) fn command() -> Command {
                 .with_name("ins")
                 .with_name("add")
                 .with_help(watchpoint_insert_help())
-                .with_exec(|_, state, _, args| {
-                    watchpoint_insert(state, &args_text(args), InsertOp::Insert)
+                .with_exec(|_, helper, args| {
+                    watchpoint_insert(&mut helper.state, &args_text(args), InsertOp::Insert)
                 }),
         )
         .with_subcommand(
@@ -69,8 +69,8 @@ pub(crate) fn command() -> Command {
                 .with_name("r")
                 .with_name("rm")
                 .with_help(watchpoint_insert_help())
-                .with_exec(|_, state, _, args| {
-                    watchpoint_insert(state, &args_text(args), InsertOp::Delete)
+                .with_exec(|_, helper, args| {
+                    watchpoint_insert(&mut helper.state, &args_text(args), InsertOp::Delete)
                 }),
         )
         .with_subcommand(
@@ -79,15 +79,15 @@ pub(crate) fn command() -> Command {
                 .with_name("temp")
                 .with_name("tmp")
                 .with_help(watchpoint_insert_help())
-                .with_exec(|_, state, _, args| {
-                    watchpoint_insert(state, &args_text(args), InsertOp::Temporary)
+                .with_exec(|_, helper, args| {
+                    watchpoint_insert(&mut helper.state, &args_text(args), InsertOp::Temporary)
                 }),
         )
         .with_subcommand(Command::new().with_name("enable").with_name("e")
             .with_help(watchpoint_toggle_help())
             .with_exec(
-            |_, state, _, args| {
-                watchpoint_toggle(state, &args_text(args), WpState::Enable)
+            |_, helper, args| {
+                watchpoint_toggle(&mut helper.state, &args_text(args), WpState::Enable)
             },
         ))
         .with_subcommand(
@@ -95,15 +95,15 @@ pub(crate) fn command() -> Command {
                 .with_name("disable")
                 .with_name("d")
                 .with_help(watchpoint_toggle_help())
-                .with_exec(|_, state, _, args| {
-                    watchpoint_toggle(state, &args_text(args), WpState::Disable)
+                .with_exec(|_, helper, args| {
+                    watchpoint_toggle(&mut helper.state, &args_text(args), WpState::Disable)
                 }),
         )
         .with_subcommand(Command::new().with_name("toggle").with_name("t")
             .with_help(watchpoint_toggle_help())
             .with_exec(
-            |_, state, _, args| {
-                watchpoint_toggle(state, &args_text(args), WpState::Toggle)
+            |_, helper, args| {
+                watchpoint_toggle(&mut helper.state, &args_text(args), WpState::Toggle)
             },
         ))
         .with_subcommand(Command::new().with_name("ignore")
@@ -125,7 +125,7 @@ pub(crate) fn command() -> Command {
             )
             )
             .with_exec(
-            |_, state, _, args| watchpoint_ignore(state, &args_text(args)),
+            |_, helper, args| watchpoint_ignore(&mut helper.state, &args_text(args)),
         ))
         .with_subcommand(
             Command::new()
@@ -151,8 +151,8 @@ pub(crate) fn command() -> Command {
                         "commands list".bold().yellow(),
                     )
                 )
-                .with_exec(|_, state, _, args| {
-                    watchpoint_commands(state, &args_text(args))
+                .with_exec(|_, helper, args| {
+                    watchpoint_commands(&mut helper.state, &args_text(args))
                 }),
     )
         .with_desc(format!(
@@ -160,14 +160,14 @@ pub(crate) fn command() -> Command {
                 "help watchpoint".bold()
         ))
         .with_help(get_long_help())
-        .with_exec(|cmd, state, helper, args| {
+        .with_exec(|cmd, helper, args| {
             match cmd
                 .subcommands
                 .iter()
                 .find(|c| c.names.contains(&args[0].to_owned().into()))
                 {
-                    Some(cmd) => (cmd._internal_exec)(cmd, state, helper, &args[1..]),
-                    None => watchpoint_insert(state, &args_text(args), InsertOp::Insert),
+                    Some(cmd) => (cmd._internal_exec)(cmd, helper, &args[1..]),
+                    None => watchpoint_insert(&mut helper.state, &args_text(args), InsertOp::Insert),
                 }
         })
 }
@@ -508,7 +508,6 @@ fn watchpoint_ignore(state: &mut State, args: &[String]) -> Result<String, Comma
 
 fn watchpoint_commands(state: &mut State, args: &[String]) -> Result<String, CommandError> {
     let binary = state.binary.as_mut().ok_or(CommandError::MustLoadFile)?;
-    state.confirm_exit = true;
     handle_commands(&args, &mut binary.watchpoints)
 }
 

--- a/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
+++ b/crates/mipsy_interactive/src/interactive/commands/watchpoint.rs
@@ -28,117 +28,110 @@ enum MipsyArgType {
     Id,
 }
 
-pub(crate) fn watchpoint_command() -> Command {
-    let subcommands = vec![
-        command(
-            "list",
-            vec!["l"],
-            vec![],
-            vec![],
-            vec![],
-            "",
-            |_, state, label, args| watchpoint_list(state, label, args),
-        ),
-        command(
-            "insert",
-            vec!["i", "in", "ins", "add"],
-            vec![],
-            vec![],
-            vec![],
-            "",
-            |_, state, label, args| watchpoint_insert(state, label, args, InsertOp::Insert),
-        ),
-        command(
-            "remove",
-            vec!["del", "delete", "r", "rm"],
-            vec![],
-            vec![],
-            vec![],
-            "",
-            |_, state, label, args| watchpoint_insert(state, label, args, InsertOp::Delete),
-        ),
-        command(
-            "temporary",
-            vec!["tmp", "temp"],
-            vec![],
-            vec![],
-            vec![],
-            "",
-            |_, state, label, args| watchpoint_insert(state, label, args, InsertOp::Temporary),
-        ),
-        command(
-            "enable",
-            vec!["e"],
-            vec![],
-            vec![],
-            vec![],
-            "",
-            |_, state, label, args| watchpoint_toggle(state, label, args, WpState::Enable),
-        ),
-        command(
-            "disable",
-            vec!["d"],
-            vec![],
-            vec![],
-            vec![],
-            "",
-            |_, state, label, args| watchpoint_toggle(state, label, args, WpState::Disable),
-        ),
-        command(
-            "toggle",
-            vec!["t"],
-            vec![],
-            vec![],
-            vec![],
-            "",
-            |_, state, label, args| watchpoint_toggle(state, label, args, WpState::Toggle),
-        ),
-        command(
-            "ignore",
-            vec![],
-            vec![],
-            vec![],
-            vec![],
-            "",
-            |_, state, label, args| watchpoint_ignore(state, label, args),
-        ),
-        command(
-            "commands",
-            vec!["com", "comms", "cmd", "cmds", "command"],
-            vec![],
-            vec![],
-            vec![],
-            "",
-            |_, state, label, args| watchpoint_commands(state, label, args),
-        ),
-    ];
+pub(super) fn args_text(args: &[ArgumentKind]) -> Vec<&String> {
+    args.iter()
+        .map(|a| match a {
+            ArgumentKind::Any(a) => a,
+            _ => unreachable!(),
+        })
+        .collect()
+}
 
-    command(
-        "watchpoint",
-        vec!["w", "wa", "wp", "watch"],
-        vec!["subcommand"],
-        vec![],
-        subcommands,
-        &format!(
+pub(crate) fn command() -> Command {
+    Command::new()
+        .with_name("watchpoint")
+        .with_name("w")
+        .with_name("wa")
+        .with_name("wp")
+        .with_name("watch")
+        .with_optional_arg(Argument::new("subcommand", |a| {
+            Ok(ArgumentKind::SubCommand(a.to_owned()))
+        }))
+        .with_subcommand(
+            Command::new()
+                .with_name("list")
+                .with_name("l")
+                .with_exec(|_, state, label, _| watchpoint_list(state, label)),
+        )
+        .with_subcommand(
+            Command::new()
+                .with_name("insert")
+                .with_name("i")
+                .with_name("in")
+                .with_name("ins")
+                .with_name("add")
+                .with_exec(|_, state, label, args| {
+                    watchpoint_insert(state, label, args, InsertOp::Insert)
+                }),
+        )
+        .with_subcommand(
+            Command::new()
+                .with_name("remove")
+                .with_name("del")
+                .with_name("delete")
+                .with_name("r")
+                .with_name("rm")
+                .with_exec(|_, state, label, args| {
+                    watchpoint_insert(state, label, args, InsertOp::Delete)
+                }),
+        )
+        .with_subcommand(
+            Command::new()
+                .with_name("temporary")
+                .with_name("temp")
+                .with_name("tmp")
+                .with_exec(|_, state, label, args| {
+                    watchpoint_insert(state, label, args, InsertOp::Temporary)
+                }),
+        )
+        .with_subcommand(Command::new().with_name("enable").with_name("e").with_exec(
+            |_, state, label, args| watchpoint_toggle(state, label, args, WpState::Enable),
+        ))
+        .with_subcommand(
+            Command::new()
+                .with_name("disable")
+                .with_name("d")
+                .with_exec(|_, state, label, args| {
+                    watchpoint_toggle(state, label, args, WpState::Disable)
+                }),
+        )
+        .with_subcommand(Command::new().with_name("toggle").with_name("t").with_exec(
+            |_, state, label, args| watchpoint_toggle(state, label, args, WpState::Toggle),
+        ))
+        .with_subcommand(
+            Command::new()
+                .with_name("ignore")
+                .with_exec(|_, state, label, args| watchpoint_ignore(state, label, args)),
+        )
+        .with_subcommand(
+            Command::new()
+                .with_name("commands")
+                .with_name("com")
+                .with_name("comms")
+                .with_name("cmd")
+                .with_name("cmds")
+                .with_name("command")
+                .with_exec(|_, state, label, args| watchpoint_commands(state, label, args)),
+        )
+        .with_desc(format!(
             "manage watchpoints ({} to list subcommands)",
             "help watchpoint".bold()
-        ),
-        |cmd, state, label, args| {
-            if label == "__help__" && args.is_empty() {
+        ))
+        .with_exec(|cmd, state, label, args| {
+            if label == "__help__" || args.is_empty() {
                 return Ok(get_long_help());
             }
 
-            let cmd = cmd
-                .subcommands
-                .iter()
-                .find(|c| c.name == args[0] || c.aliases.contains(&args[0]));
-            match cmd {
+            match if let ArgumentKind::SubCommand(arg) = &args[0] {
+                cmd.subcommands.iter().find(|c| c.names.contains(&arg))
+            } else {
+                None
+            } {
                 None if label == "__help__" => Ok(get_long_help()),
-                Some(cmd) => cmd.exec(state, label, &args[1..]),
+                Some(cmd) => (cmd._internal_exec)(cmd, state, label, &args[1..]),
                 None => watchpoint_insert(state, label, args, InsertOp::Insert),
             }
-        },
-    )
+        })
 }
 
 fn get_long_help() -> String {
@@ -175,7 +168,7 @@ fn get_long_help() -> String {
 fn watchpoint_insert(
     state: &mut State,
     label: &str,
-    args: &[String],
+    args: &[ArgumentKind],
     op: InsertOp,
 ) -> Result<String, CommandError> {
     if label == "__help__" {
@@ -214,7 +207,7 @@ fn watchpoint_insert(
         return Err(generate_err(
             CommandError::MissingArguments {
                 args: vec!["target".to_string()],
-                instead: args.to_vec(),
+                instead: vec![],
             },
             match op {
                 InsertOp::Insert => "insert",
@@ -224,7 +217,8 @@ fn watchpoint_insert(
         ));
     }
 
-    let (target, arg_type) = parse_watchpoint_arg(state, &args[0])?;
+    let args = args_text(args);
+    let (target, arg_type) = parse_watchpoint_arg(state, args[0])?;
     let binary = state.binary.as_mut().ok_or(CommandError::MustLoadFile)?;
 
     let id;
@@ -251,7 +245,7 @@ fn watchpoint_insert(
             return Err(generate_err(
                 CommandError::MissingArguments {
                     args: vec!["action".to_string()],
-                    instead: args.to_vec(),
+                    instead: args.iter().map(|&s| s.clone()).collect(),
                 },
                 "rm",
             ));
@@ -291,7 +285,7 @@ fn watchpoint_insert(
 
     let label = match arg_type {
         MipsyArgType::Target => None,
-        MipsyArgType::Label => Some(&args[0]),
+        MipsyArgType::Label => Some(args[0]),
         MipsyArgType::Id => match target {
             WatchpointTarget::Register(_) => None,
             WatchpointTarget::MemAddr(addr) => binary
@@ -328,7 +322,7 @@ fn watchpoint_insert(
     Ok("".into())
 }
 
-fn watchpoint_list(state: &State, label: &str, _args: &[String]) -> Result<String, CommandError> {
+fn watchpoint_list(state: &State, label: &str) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok("Lists currently set watchpoints.".to_string());
     }
@@ -411,7 +405,7 @@ fn watchpoint_list(state: &State, label: &str, _args: &[String]) -> Result<Strin
 fn watchpoint_toggle(
     state: &mut State,
     label: &str,
-    args: &[String],
+    args: &[ArgumentKind],
     op: WpState,
 ) -> Result<String, CommandError> {
     if label == "__help__" {
@@ -439,7 +433,7 @@ fn watchpoint_toggle(
         return Err(generate_err(
             CommandError::MissingArguments {
                 args: vec!["addr".to_string()],
-                instead: args.to_vec(),
+                instead: vec![],
             },
             match op {
                 WpState::Enable => "enable",
@@ -449,7 +443,8 @@ fn watchpoint_toggle(
         ));
     }
 
-    let (target, arg_type) = parse_watchpoint_arg(state, &args[0])?;
+    let args = args_text(args);
+    let (target, arg_type) = parse_watchpoint_arg(state, args[0])?;
 
     let binary = state.binary.as_mut().ok_or(CommandError::MustLoadFile)?;
 
@@ -481,7 +476,7 @@ fn watchpoint_toggle(
 
     let label = match arg_type {
         MipsyArgType::Target => None,
-        MipsyArgType::Label => Some(&args[0]),
+        MipsyArgType::Label => Some(args[0]),
         MipsyArgType::Id => match target {
             WatchpointTarget::Register(_) => None,
             WatchpointTarget::MemAddr(addr) => binary
@@ -512,7 +507,7 @@ fn watchpoint_toggle(
 fn watchpoint_ignore(
     state: &mut State,
     label: &str,
-    mut args: &[String],
+    args: &[ArgumentKind],
 ) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(
@@ -538,20 +533,21 @@ fn watchpoint_ignore(
         return Err(generate_err(
             CommandError::MissingArguments {
                 args: vec!["addr".to_string()],
-                instead: args.to_vec(),
+                instead: vec![],
             },
             "ignore",
         ));
     }
 
-    let (target, arg_type) = parse_watchpoint_arg(state, &args[0])?;
+    let args = args_text(args);
+    let (target, arg_type) = parse_watchpoint_arg(state, args[0])?;
 
-    args = &args[1..];
+    let args = &args[1..];
     if args.is_empty() {
         return Err(generate_err(
             CommandError::MissingArguments {
                 args: vec!["ignore count".to_string()],
-                instead: args.to_vec(),
+                instead: args.iter().map(|&s| s.clone()).collect(),
             },
             "ignore",
         ));
@@ -592,7 +588,7 @@ fn watchpoint_ignore(
 fn watchpoint_commands(
     state: &mut State,
     label: &str,
-    args: &[String],
+    args: &[ArgumentKind],
 ) -> Result<String, CommandError> {
     if label == "__help__" {
         return Ok(format!(
@@ -613,7 +609,14 @@ fn watchpoint_commands(
 
     let binary = state.binary.as_mut().ok_or(CommandError::MustLoadFile)?;
     state.confirm_exit = true;
-    handle_commands(args, &mut binary.watchpoints)
+    handle_commands(
+        args_text(args)
+            .into_iter()
+            .map(String::clone)
+            .collect::<Vec<_>>()
+            .as_slice(),
+        &mut binary.watchpoints,
+    )
 }
 
 fn generate_err(error: CommandError, command_name: impl Into<String>) -> CommandError {

--- a/crates/mipsy_interactive/src/interactive/helper.rs
+++ b/crates/mipsy_interactive/src/interactive/helper.rs
@@ -81,7 +81,7 @@ impl Completer for MyHelper {
                     .collect(),
                 )
             } else {
-                (0, vec![])
+                x
             })
         })
     }

--- a/crates/mipsy_interactive/src/interactive/helper.rs
+++ b/crates/mipsy_interactive/src/interactive/helper.rs
@@ -29,10 +29,22 @@ impl MyHelper {
         self.defaults = defaults
     }
 
-    fn closest(&self, with: &Vec<String>, line: &str, pos: usize) -> Option<String> {
+    fn closest<'a>(&self, with: &Vec<&'a str>, line: &str, pos: usize) -> Vec<&'a str> {
+        if line.is_empty() || pos < line.len() {
+            vec![]
+        } else {
+            with.iter()
+                .filter(|m| m.len() != pos)
+                .filter(|m| m.starts_with(line))
+                .map(|m| *m)
+                .collect()
+        }
+    }
+
+    fn closest_default(&self, line: &str, pos: usize) -> Option<String> {
         if line.is_empty() || pos < line.len() {
             None
-        } else if let Some(found) = with.iter().find(|s| s.starts_with(line)) {
+        } else if let Some(found) = self.defaults.iter().find(|s| s.starts_with(line)) {
             if found.len() == pos {
                 None
             } else {
@@ -65,9 +77,10 @@ impl Completer for MyHelper {
                             ctx.history()
                                 .iter()
                                 .rev()
-                                .map(|h| h.to_owned())
-                                .collect::<Vec<String>>(),
-                            self.defaults.clone(),
+                                .filter(|h| !self.defaults.contains(h))
+                                .map(|h| &h[..])
+                                .collect::<Vec<&str>>(),
+                            self.defaults.iter().map(|s| &s[..]).collect(),
                         ]
                         .concat(),
                         line,
@@ -75,8 +88,8 @@ impl Completer for MyHelper {
                     )
                     .iter()
                     .map(|m| Pair {
-                        display: m.to_owned(),
-                        replacement: m.to_owned(),
+                        display: m.to_string(),
+                        replacement: m[pos..].to_owned(),
                     })
                     .collect(),
                 )
@@ -93,7 +106,7 @@ impl Hinter for MyHelper {
     fn hint(&self, line: &str, pos: usize, ctx: &Context<'_>) -> Option<String> {
         self.hinter
             .hint(line, pos, ctx)
-            .or(self.closest(&self.defaults, line, pos))
+            .or(self.closest_default(line, pos))
     }
 }
 

--- a/crates/mipsy_interactive/src/interactive/helper.rs
+++ b/crates/mipsy_interactive/src/interactive/helper.rs
@@ -36,7 +36,7 @@ impl MyHelper {
             with.iter()
                 .filter(|m| m.len() != pos)
                 .filter(|m| m.starts_with(line))
-                .map(|m| *m)
+                .copied()
                 .collect()
         }
     }
@@ -78,9 +78,12 @@ impl Completer for MyHelper {
                                 .iter()
                                 .rev()
                                 .filter(|h| !self.defaults.contains(h))
-                                .map(|h| &h[..])
+                                .filter(|h| !ctx.history().iter().collect::<Vec<&String>>().contains(h))
+                                .map(String::as_str)
                                 .collect::<Vec<&str>>(),
-                            self.defaults.iter().map(|s| &s[..]).collect(),
+                            self.defaults.iter()
+                                .map(String::as_str)
+.collect(),
                         ]
                         .concat(),
                         line,

--- a/crates/mipsy_interactive/src/interactive/helper.rs
+++ b/crates/mipsy_interactive/src/interactive/helper.rs
@@ -2,7 +2,7 @@ use rustyline::{
     completion::{Candidate, Completer, FilenameCompleter, Pair},
     error::ReadlineError,
     highlight::Highlighter,
-    hint::{Hinter, HistoryHinter},
+    hint::Hinter,
     validate::{ValidationContext, ValidationResult, Validator},
     Context,
 };
@@ -12,12 +12,21 @@ use std::{
     ptr::NonNull,
 };
 
-use crate::interactive::commands::{Argument, ArgumentKind, Arguments, Command};
+use crate::interactive::{commands::Command, State};
 
-#[derive(Clone)]
+#[derive(Default)]
 pub(crate) struct HintArgs {
     pub(crate) line: String,
     pub(crate) pos: usize,
+}
+
+impl From<String> for HintArgs {
+    fn from(value: String) -> Self {
+        Self {
+            pos: value.len(),
+            line: value
+        }
+    }
 }
 
 impl HintArgs {
@@ -33,8 +42,8 @@ impl HintArgs {
 
     fn pair(&self, s: String) -> Pair {
         Pair {
-            display: s.clone(),
             replacement: s[self.pos.min(s.len())..].to_owned(),
+            display: s,
         }
     }
 
@@ -48,8 +57,24 @@ impl HintArgs {
             + self.line[..self.pos].split_whitespace().skip(1).count()
     }
 
+    pub(crate) fn command(&self) -> Option<Self> {
+        self.line.split_whitespace().nth(0).filter(|l| l != &self.line).and_then(|l|
+            Some(Self {
+                line: l.to_owned(),
+                pos: l.len()
+            })
+            )
+    }
+
     pub(crate) fn subcmd(&self) -> Self {
-        let line = self.line.split_whitespace().last().expect("impossible");
+        let line = self
+            .line
+            .split_whitespace()
+            .last()
+            .filter(|l| l.trim() != self.line.trim())
+            .or(Some(""))
+            .unwrap();
+
         Self {
             line: line.to_owned(),
             pos: line.len(),
@@ -64,23 +89,33 @@ impl HintArgs {
 #[derive(Helper)]
 pub(crate) struct MyHelper<'a> {
     completer: FilenameCompleter,
-    hinter: HistoryHinter,
-    pub(crate) commands: &'a [Command],
+    pub(crate) state: &'a State,
 }
 
 impl<'a> MyHelper<'a> {
-    pub(super) fn new(commands: &'a [Command]) -> Self {
+    pub(super) fn new(state: &'a State) -> Self {
         Self {
             completer: FilenameCompleter::new(),
-            hinter: HistoryHinter {},
-            commands: commands,
+            state,
         }
     }
 
-    fn command(&self, line: &str) -> Option<&Command> {
-        line.split_whitespace()
-            .nth(0)
-            .and_then(|c| self.commands.iter().find(|d| d.name() == c))
+    fn find_command_name(&self, hargs: &HintArgs) -> Option<&Command> {
+        hargs.command().and_then(|l| {
+            self.state
+                .commands
+                .iter()
+                .find(|c| c.name() == l.line)
+        })
+    }
+
+    fn find_command_aliases(&self, hargs: &HintArgs) -> Option<&Command> {
+        hargs.command().and_then(|l| {
+            self.state
+                .commands
+                .iter()
+                .find(|c| c.names.contains(&l.line))
+        })
     }
 
     pub(crate) fn closest_hints<'b>(&self, with: &[&'b str], hargs: &HintArgs) -> Vec<&'b str> {
@@ -95,6 +130,7 @@ impl<'a> MyHelper<'a> {
         if hargs.line.is_empty() || hargs.pos < hargs.line.len() {
             None
         } else if let Some(found) = self
+            .state
             .commands
             .iter()
             .find(|s| s.name().starts_with(&hargs.line))
@@ -110,12 +146,12 @@ impl<'a> MyHelper<'a> {
         }
     }
 
-    fn history_hints(&self, hargs: &HintArgs, ctx: &'a Context<'_>) -> Vec<String> {
+    fn history_hints(&self, hargs: &HintArgs, ctx: &Context<'_>) -> Vec<String> {
         self.closest_hints(
             &ctx.history()
                 .iter()
                 .rev()
-                .filter(|h| self.command(h).is_none())
+                .filter(|&h| self.find_command_name(&h.to_owned().into()).is_none())
                 .filter(|h| !ctx.history().iter().find(|a| a == h).is_none())
                 .map(|h| h.trim())
                 .collect::<Vec<_>>(),
@@ -129,7 +165,12 @@ impl<'a> MyHelper<'a> {
 
     fn close_command_hints(&self, hargs: &HintArgs) -> Vec<String> {
         self.closest_hints(
-            &self.commands.iter().map(Command::name).collect::<Vec<_>>(),
+            &self
+                .state
+                .commands
+                .iter()
+                .map(Command::name)
+                .collect::<Vec<_>>(),
             hargs,
         )
         .iter()
@@ -192,16 +233,13 @@ impl Completer for MyHelper<'_> {
             hints.extend(history)
         }
 
-        hints.extend_from_slice(
-            match self.command(line) {
-                Some(cmd) => cmd
-                    .args()
-                    .get(hargs.subcmd_index().saturating_sub(1))
-                    .map_or(vec![], |a| a.hints(hargs.clone(), self)),
-                None => self.close_command_hints(&hargs),
-            }
-            .as_slice(),
-        );
+        hints.extend(match self.find_command_aliases(&line.to_owned().into()) {
+            Some(cmd) => cmd
+                .args()
+                .get(hargs.subcmd_index().saturating_sub(1))
+                .map_or(vec![], |a| a.hints(&hargs, self)),
+            None => self.close_command_hints(&hargs),
+        });
 
         Ok(hargs.hints(hints.iter().collect::<Vec<_>>().as_slice()))
     }
@@ -214,11 +252,6 @@ impl Hinter for MyHelper<'_> {
         self.complete(line, pos, ctx)
             .ok()
             .and_then(|(_, p)| p.get(0).and_then(|p| Some(p.replacement.clone())))
-
-        // let hargs = HintArgs { line, pos };
-        // self.hinter
-        //     .hint(line, pos, ctx)
-        //     .or(self.closest_command(&hargs))
     }
 }
 

--- a/crates/mipsy_interactive/src/interactive/helper.rs
+++ b/crates/mipsy_interactive/src/interactive/helper.rs
@@ -20,8 +20,9 @@ pub(crate) struct HintArgs {
     pub(crate) pos: usize,
 }
 
-impl From<String> for HintArgs {
-    fn from(value: String) -> Self {
+impl<S: Into<String>> From<S> for HintArgs {
+    fn from(value: S) -> Self {
+        let value = value.into();
         Self {
             pos: value.len(),
             line: value,
@@ -62,27 +63,18 @@ impl HintArgs {
             .split_whitespace()
             .nth(0)
             .filter(|l| l != &self.line)
-            .and_then(|l| {
-                Some(Self {
-                    line: l.to_owned(),
-                    pos: l.len(),
-                })
-            })
+            .and_then(|l| Some(Self::from(l)))
     }
 
     pub(crate) fn subcmd(&self) -> Self {
-        let line = self
-            .line
-            .split_whitespace()
-            .last()
-            .filter(|l| l.trim() != self.line.trim())
-            .or(Some(""))
-            .unwrap();
-
-        Self {
-            line: line.to_owned(),
-            pos: line.len(),
-        }
+        Self::from(
+            self.line
+                .split_whitespace()
+                .last()
+                .filter(|l| l.trim() != self.line.trim())
+                .or(Some(""))
+                .unwrap(),
+        )
     }
 
     pub(crate) fn recontextualize(&self, sub: &str) -> String {
@@ -105,9 +97,12 @@ impl<'a> MyHelper<'a> {
     }
 
     fn find_command_name(&self, hargs: &HintArgs) -> Option<&Command> {
-        hargs
-            .command()
-            .and_then(|l| self.state.commands.iter().find(|c| c.name() == l.line))
+        hargs.command().and_then(|l| {
+            self.state
+                .commands
+                .iter()
+                .find(|c| c.name() == l.line.trim())
+        })
     }
 
     fn find_command_aliases(&self, hargs: &HintArgs) -> Option<&Command> {
@@ -115,7 +110,7 @@ impl<'a> MyHelper<'a> {
             self.state
                 .commands
                 .iter()
-                .find(|c| c.names.contains(&l.line))
+                .find(|c| c.names.contains(&l.line.trim().to_owned()))
         })
     }
 
@@ -132,8 +127,7 @@ impl<'a> MyHelper<'a> {
             &ctx.history()
                 .iter()
                 .rev()
-                .filter(|&h| self.find_command_name(&h.to_owned().into()).is_none())
-                .filter(|h| !ctx.history().iter().find(|a| a == h).is_none())
+                // .filter(|&h| self.find_command_name(&h.into()).is_none())
                 .map(|h| h.trim())
                 .collect::<Vec<_>>(),
             hargs,
@@ -158,6 +152,24 @@ impl<'a> MyHelper<'a> {
         .copied()
         .map(str::to_owned)
         .collect()
+    }
+
+    pub(crate) fn command_hints(&self, hargs: &HintArgs) -> Vec<String> {
+        let mut hints = vec![];
+
+        if let None = self.find_command_name(&hargs) {
+            hints.extend(self.close_command_hints(&hargs))
+        }
+
+        if let Some(cmd) = self.find_command_aliases(hargs) {
+            hints.extend(
+                cmd.args()
+                    .get(hargs.subcmd_index().saturating_sub(1))
+                    .map_or(vec![], |a| a.hints(cmd, &hargs, self)),
+            )
+        }
+
+        hints
     }
 
     pub(crate) fn file_hints(&self, hargs: &HintArgs) -> Vec<String> {
@@ -214,13 +226,7 @@ impl Completer for MyHelper<'_> {
             hints.extend(history)
         }
 
-        hints.extend(match self.find_command_aliases(&line.to_owned().into()) {
-            Some(cmd) => cmd
-                .args()
-                .get(hargs.subcmd_index().saturating_sub(1))
-                .map_or(vec![], |a| a.hints(&hargs, self)),
-            None => self.close_command_hints(&hargs),
-        });
+        hints.extend(self.command_hints(&hargs));
 
         Ok(hargs.hints(hints.iter().collect::<Vec<_>>().as_slice()))
     }

--- a/crates/mipsy_interactive/src/interactive/helper.rs
+++ b/crates/mipsy_interactive/src/interactive/helper.rs
@@ -13,6 +13,7 @@ use std::borrow::Cow::{self, Borrowed, Owned};
 pub(crate) struct MyHelper {
     completer: FilenameCompleter,
     hinter: HistoryHinter,
+    defaults: Vec<String>,
 }
 
 impl MyHelper {
@@ -20,6 +21,25 @@ impl MyHelper {
         Self {
             completer: FilenameCompleter::new(),
             hinter: HistoryHinter {},
+            defaults: vec![],
+        }
+    }
+
+    pub(super) fn set_defaults(&mut self, defaults: Vec<String>) {
+        self.defaults = defaults
+    }
+
+    fn closest(&self, with: &Vec<String>, line: &str, pos: usize) -> Option<String> {
+        if line.is_empty() || pos < line.len() {
+            None
+        } else if let Some(found) = with.iter().find(|s| s.starts_with(line)) {
+            if found.len() == pos {
+                None
+            } else {
+                Some(found[pos..].to_owned())
+            }
+        } else {
+            None
         }
     }
 }
@@ -33,7 +53,37 @@ impl Completer for MyHelper {
         pos: usize,
         ctx: &Context<'_>,
     ) -> Result<(usize, Vec<Pair>), ReadlineError> {
-        self.completer.complete(line, pos, ctx)
+        self.completer.complete(line, pos, ctx).and_then(|x| {
+            // will be 0 for first arg. kinda a hacky way to check if we should match
+            // against files or not but thats okay.
+            // TODO: something like `match self.arg_type() { label => , file => number => }`
+            Ok(if x.0 == 0 {
+                (
+                    pos,
+                    self.closest(
+                        &[
+                            ctx.history()
+                                .iter()
+                                .rev()
+                                .map(|h| h.to_owned())
+                                .collect::<Vec<String>>(),
+                            self.defaults.clone(),
+                        ]
+                        .concat(),
+                        line,
+                        pos,
+                    )
+                    .iter()
+                    .map(|m| Pair {
+                        display: m.to_owned(),
+                        replacement: m.to_owned(),
+                    })
+                    .collect(),
+                )
+            } else {
+                (0, vec![])
+            })
+        })
     }
 }
 
@@ -41,7 +91,9 @@ impl Hinter for MyHelper {
     type Hint = String;
 
     fn hint(&self, line: &str, pos: usize, ctx: &Context<'_>) -> Option<String> {
-        self.hinter.hint(line, pos, ctx)
+        self.hinter
+            .hint(line, pos, ctx)
+            .or(self.closest(&self.defaults, line, pos))
     }
 }
 

--- a/crates/mipsy_interactive/src/interactive/helper.rs
+++ b/crates/mipsy_interactive/src/interactive/helper.rs
@@ -24,7 +24,7 @@ impl From<String> for HintArgs {
     fn from(value: String) -> Self {
         Self {
             pos: value.len(),
-            line: value
+            line: value,
         }
     }
 }
@@ -58,12 +58,16 @@ impl HintArgs {
     }
 
     pub(crate) fn command(&self) -> Option<Self> {
-        self.line.split_whitespace().nth(0).filter(|l| l != &self.line).and_then(|l|
-            Some(Self {
-                line: l.to_owned(),
-                pos: l.len()
+        self.line
+            .split_whitespace()
+            .nth(0)
+            .filter(|l| l != &self.line)
+            .and_then(|l| {
+                Some(Self {
+                    line: l.to_owned(),
+                    pos: l.len(),
+                })
             })
-            )
     }
 
     pub(crate) fn subcmd(&self) -> Self {
@@ -101,12 +105,9 @@ impl<'a> MyHelper<'a> {
     }
 
     fn find_command_name(&self, hargs: &HintArgs) -> Option<&Command> {
-        hargs.command().and_then(|l| {
-            self.state
-                .commands
-                .iter()
-                .find(|c| c.name() == l.line)
-        })
+        hargs
+            .command()
+            .and_then(|l| self.state.commands.iter().find(|c| c.name() == l.line))
     }
 
     fn find_command_aliases(&self, hargs: &HintArgs) -> Option<&Command> {
@@ -124,26 +125,6 @@ impl<'a> MyHelper<'a> {
             .filter(|m| m.starts_with(&hargs.line))
             .copied()
             .collect()
-    }
-
-    fn closest_command(&self, hargs: &HintArgs) -> Option<String> {
-        if hargs.line.is_empty() || hargs.pos < hargs.line.len() {
-            None
-        } else if let Some(found) = self
-            .state
-            .commands
-            .iter()
-            .find(|s| s.name().starts_with(&hargs.line))
-        {
-            let found = found.name();
-            if found.len() == hargs.pos {
-                None
-            } else {
-                Some(found[hargs.pos..].to_owned())
-            }
-        } else {
-            None
-        }
     }
 
     fn history_hints(&self, hargs: &HintArgs, ctx: &Context<'_>) -> Vec<String> {

--- a/crates/mipsy_interactive/src/interactive/helper.rs
+++ b/crates/mipsy_interactive/src/interactive/helper.rs
@@ -70,6 +70,7 @@ impl HintArgs {
         self.line
             .split_whitespace()
             .last()
+            .filter(|_| !self.line.ends_with(' '))
             .filter(|l| l.trim() != self.line.trim())
             .or(Some(""))
             .unwrap()
@@ -162,7 +163,7 @@ impl MyHelper {
 
         if let Some(cmd) = self.find_command_aliases(hargs) {
             hints.extend(
-                cmd.args()
+                cmd.args(hargs.line.split_whitespace().count())
                     .get(hargs.subcmd_index().saturating_sub(1))
                     .map_or(vec![], |a| a.hints(cmd, &hargs, self)),
             )

--- a/crates/mipsy_interactive/src/interactive/helper.rs
+++ b/crates/mipsy_interactive/src/interactive/helper.rs
@@ -67,14 +67,13 @@ impl HintArgs {
     }
 
     pub(crate) fn subcmd(&self) -> Self {
-        Self::from(
-            self.line
-                .split_whitespace()
-                .last()
-                .filter(|l| l.trim() != self.line.trim())
-                .or(Some(""))
-                .unwrap(),
-        )
+        self.line
+            .split_whitespace()
+            .last()
+            .filter(|l| l.trim() != self.line.trim())
+            .or(Some(""))
+            .unwrap()
+            .into()
     }
 
     pub(crate) fn recontextualize(&self, sub: &str) -> String {
@@ -83,16 +82,16 @@ impl HintArgs {
 }
 
 #[derive(Helper)]
-pub(crate) struct MyHelper<'a> {
+pub(crate) struct MyHelper {
+    pub(crate) state: State,
     completer: FilenameCompleter,
-    pub(crate) state: &'a State,
 }
 
-impl<'a> MyHelper<'a> {
-    pub(super) fn new(state: &'a State) -> Self {
+impl MyHelper {
+    pub(super) fn new(state: State) -> Self {
         Self {
-            completer: FilenameCompleter::new(),
             state,
+            completer: FilenameCompleter::new(),
         }
     }
 
@@ -198,7 +197,7 @@ impl<'a> MyHelper<'a> {
     }
 }
 
-impl Completer for MyHelper<'_> {
+impl Completer for MyHelper {
     type Candidate = Pair;
 
     fn complete(
@@ -232,7 +231,7 @@ impl Completer for MyHelper<'_> {
     }
 }
 
-impl Hinter for MyHelper<'_> {
+impl Hinter for MyHelper {
     type Hint = String;
 
     fn hint(&self, line: &str, pos: usize, ctx: &Context<'_>) -> Option<String> {
@@ -242,7 +241,7 @@ impl Hinter for MyHelper<'_> {
     }
 }
 
-impl Highlighter for MyHelper<'_> {
+impl Highlighter for MyHelper {
     fn highlight_prompt<'b, 's: 'b, 'p: 'b>(
         &'s self,
         prompt: &'p str,
@@ -264,7 +263,7 @@ impl Highlighter for MyHelper<'_> {
     }
 }
 
-impl Validator for MyHelper<'_> {
+impl Validator for MyHelper {
     fn validate(&self, _ctx: &mut ValidationContext) -> rustyline::Result<ValidationResult> {
         Ok(ValidationResult::Valid(None))
     }

--- a/crates/mipsy_interactive/src/interactive/helper.rs
+++ b/crates/mipsy_interactive/src/interactive/helper.rs
@@ -1,5 +1,5 @@
 use rustyline::{
-    completion::{Completer, FilenameCompleter, Pair},
+    completion::{Candidate, Completer, FilenameCompleter, Pair},
     error::ReadlineError,
     highlight::Highlighter,
     hint::{Hinter, HistoryHinter},
@@ -7,56 +7,164 @@ use rustyline::{
     Context,
 };
 use rustyline_derive::Helper;
-use std::borrow::Cow::{self, Borrowed, Owned};
+use std::{
+    borrow::Cow::{self, Borrowed, Owned},
+    ptr::NonNull,
+};
 
-#[derive(Helper)]
-pub(crate) struct MyHelper {
-    completer: FilenameCompleter,
-    hinter: HistoryHinter,
-    defaults: Vec<String>,
+use crate::interactive::commands::{Argument, ArgumentKind, Arguments, Command};
+
+#[derive(Clone)]
+pub(crate) struct HintArgs {
+    pub(crate) line: String,
+    pub(crate) pos: usize,
 }
 
-impl MyHelper {
-    pub(super) fn new() -> Self {
+impl HintArgs {
+    fn hints(&self, strs: &[&String]) -> (usize, Vec<Pair>) {
+        (
+            self.pos,
+            strs.iter()
+                .cloned()
+                .map(|h| self.pair(h.to_owned()))
+                .collect(),
+        )
+    }
+
+    fn pair(&self, s: String) -> Pair {
+        Pair {
+            display: s.clone(),
+            replacement: s[self.pos.min(s.len())..].to_owned(),
+        }
+    }
+
+    fn subcmd_index(&self) -> usize {
+        self.line
+            .trim_start()
+            .chars()
+            .last()
+            .unwrap_or_default()
+            .is_whitespace() as usize
+            + self.line[..self.pos].split_whitespace().skip(1).count()
+    }
+
+    pub(crate) fn subcmd(&self) -> Self {
+        let line = self.line.split_whitespace().last().expect("impossible");
+        Self {
+            line: line.to_owned(),
+            pos: line.len(),
+        }
+    }
+
+    pub(crate) fn recontextualize(&self, sub: &str) -> String {
+        self.line[..self.line.len() - self.subcmd().line.len()].to_owned() + &sub
+    }
+}
+
+#[derive(Helper)]
+pub(crate) struct MyHelper<'a> {
+    completer: FilenameCompleter,
+    hinter: HistoryHinter,
+    pub(crate) commands: &'a [Command],
+}
+
+impl<'a> MyHelper<'a> {
+    pub(super) fn new(commands: &'a [Command]) -> Self {
         Self {
             completer: FilenameCompleter::new(),
             hinter: HistoryHinter {},
-            defaults: vec![],
+            commands: commands,
         }
     }
 
-    pub(super) fn set_defaults(&mut self, defaults: Vec<String>) {
-        self.defaults = defaults
+    fn command(&self, line: &str) -> Option<&Command> {
+        line.split_whitespace()
+            .nth(0)
+            .and_then(|c| self.commands.iter().find(|d| d.name() == c))
     }
 
-    fn closest<'a>(&self, with: &Vec<&'a str>, line: &str, pos: usize) -> Vec<&'a str> {
-        if line.is_empty() || pos < line.len() {
-            vec![]
-        } else {
-            with.iter()
-                .filter(|m| m.len() != pos)
-                .filter(|m| m.starts_with(line))
-                .copied()
-                .collect()
-        }
+    pub(crate) fn closest_hints<'b>(&self, with: &[&'b str], hargs: &HintArgs) -> Vec<&'b str> {
+        with.iter()
+            .filter(|m| m.len() != hargs.pos)
+            .filter(|m| m.starts_with(&hargs.line))
+            .copied()
+            .collect()
     }
 
-    fn closest_default(&self, line: &str, pos: usize) -> Option<String> {
-        if line.is_empty() || pos < line.len() {
+    fn closest_command(&self, hargs: &HintArgs) -> Option<String> {
+        if hargs.line.is_empty() || hargs.pos < hargs.line.len() {
             None
-        } else if let Some(found) = self.defaults.iter().find(|s| s.starts_with(line)) {
-            if found.len() == pos {
+        } else if let Some(found) = self
+            .commands
+            .iter()
+            .find(|s| s.name().starts_with(&hargs.line))
+        {
+            let found = found.name();
+            if found.len() == hargs.pos {
                 None
             } else {
-                Some(found[pos..].to_owned())
+                Some(found[hargs.pos..].to_owned())
             }
         } else {
             None
         }
     }
+
+    fn history_hints(&self, hargs: &HintArgs, ctx: &'a Context<'_>) -> Vec<String> {
+        self.closest_hints(
+            &ctx.history()
+                .iter()
+                .rev()
+                .filter(|h| self.command(h).is_none())
+                .filter(|h| !ctx.history().iter().find(|a| a == h).is_none())
+                .map(|h| h.trim())
+                .collect::<Vec<_>>(),
+            hargs,
+        )
+        .iter()
+        .copied()
+        .map(str::to_owned)
+        .collect()
+    }
+
+    fn close_command_hints(&self, hargs: &HintArgs) -> Vec<String> {
+        self.closest_hints(
+            &self.commands.iter().map(Command::name).collect::<Vec<_>>(),
+            hargs,
+        )
+        .iter()
+        .copied()
+        .map(str::to_owned)
+        .collect()
+    }
+
+    pub(crate) fn file_hints(&self, hargs: &HintArgs) -> Vec<String> {
+        self.completer
+            .complete(&hargs.line, hargs.pos, unsafe {
+                NonNull::dangling().as_ref()
+            })
+            .map(|(_, p)| p)
+            .unwrap_or_default()
+            .iter()
+            .map(Pair::display)
+            .map(str::to_owned)
+            .collect()
+    }
+
+    pub(crate) fn subcmd_hints(&self, hargs: &HintArgs, subcmd: &Command) -> Vec<String> {
+        // TODO: recursive subcmds based on `hargs.subcmd_index`
+        self.closest_hints(
+            &subcmd.names.iter().map(String::as_str).collect::<Vec<_>>(),
+            hargs,
+        )
+        .iter()
+        .copied()
+        .map(str::to_owned)
+        .collect()
+    }
 }
 
-impl Completer for MyHelper {
+impl Completer for MyHelper<'_> {
     type Candidate = Pair;
 
     fn complete(
@@ -65,52 +173,56 @@ impl Completer for MyHelper {
         pos: usize,
         ctx: &Context<'_>,
     ) -> Result<(usize, Vec<Pair>), ReadlineError> {
-        self.completer.complete(line, pos, ctx).and_then(|x| {
-            Ok(if x.0 == 0 {
-                (
-                    pos,
-                    self.closest(
-                        &[
-                            ctx.history()
-                                .iter()
-                                .rev()
-                                .filter(|h| !self.defaults.contains(h))
-                                .filter(|h| {
-                                    !ctx.history().iter().collect::<Vec<&String>>().contains(h)
-                                })
-                                .map(|h| h.trim())
-                                .collect::<Vec<&str>>(),
-                            self.defaults.iter().map(String::as_str).collect(),
-                        ]
-                        .concat(),
-                        line,
-                        pos,
-                    )
-                    .iter()
-                    .map(|m| Pair {
-                        display: m.to_string(),
-                        replacement: m[pos..].to_owned(),
-                    })
-                    .collect(),
-                )
-            } else {
-                x
-            })
-        })
+        if pos < line.len() {
+            return Ok((0, vec![]));
+        }
+
+        let mut hints = vec![];
+        let hargs = HintArgs {
+            line: line.to_owned(),
+            pos,
+        };
+
+        if line.is_empty() {
+            hints.push("".to_owned());
+        }
+
+        let history = self.history_hints(&hargs, ctx);
+        if history.len() != 0 {
+            hints.extend(history)
+        }
+
+        hints.extend_from_slice(
+            match self.command(line) {
+                Some(cmd) => cmd
+                    .args()
+                    .get(hargs.subcmd_index().saturating_sub(1))
+                    .map_or(vec![], |a| a.hints(hargs.clone(), self)),
+                None => self.close_command_hints(&hargs),
+            }
+            .as_slice(),
+        );
+
+        Ok(hargs.hints(hints.iter().collect::<Vec<_>>().as_slice()))
     }
 }
 
-impl Hinter for MyHelper {
+impl Hinter for MyHelper<'_> {
     type Hint = String;
 
     fn hint(&self, line: &str, pos: usize, ctx: &Context<'_>) -> Option<String> {
-        self.hinter
-            .hint(line, pos, ctx)
-            .or(self.closest_default(line, pos))
+        self.complete(line, pos, ctx)
+            .ok()
+            .and_then(|(_, p)| p.get(0).and_then(|p| Some(p.replacement.clone())))
+
+        // let hargs = HintArgs { line, pos };
+        // self.hinter
+        //     .hint(line, pos, ctx)
+        //     .or(self.closest_command(&hargs))
     }
 }
 
-impl Highlighter for MyHelper {
+impl Highlighter for MyHelper<'_> {
     fn highlight_prompt<'b, 's: 'b, 'p: 'b>(
         &'s self,
         prompt: &'p str,
@@ -132,7 +244,7 @@ impl Highlighter for MyHelper {
     }
 }
 
-impl Validator for MyHelper {
+impl Validator for MyHelper<'_> {
     fn validate(&self, _ctx: &mut ValidationContext) -> rustyline::Result<ValidationResult> {
         Ok(ValidationResult::Valid(None))
     }

--- a/crates/mipsy_interactive/src/interactive/helper.rs
+++ b/crates/mipsy_interactive/src/interactive/helper.rs
@@ -66,9 +66,6 @@ impl Completer for MyHelper {
         ctx: &Context<'_>,
     ) -> Result<(usize, Vec<Pair>), ReadlineError> {
         self.completer.complete(line, pos, ctx).and_then(|x| {
-            // will be 0 for first arg. kinda a hacky way to check if we should match
-            // against files or not but thats okay.
-            // TODO: something like `match self.arg_type() { label => , file => number => }`
             Ok(if x.0 == 0 {
                 (
                     pos,
@@ -78,12 +75,12 @@ impl Completer for MyHelper {
                                 .iter()
                                 .rev()
                                 .filter(|h| !self.defaults.contains(h))
-                                .filter(|h| !ctx.history().iter().collect::<Vec<&String>>().contains(h))
-                                .map(String::as_str)
+                                .filter(|h| {
+                                    !ctx.history().iter().collect::<Vec<&String>>().contains(h)
+                                })
+                                .map(|h| h.trim())
                                 .collect::<Vec<&str>>(),
-                            self.defaults.iter()
-                                .map(String::as_str)
-.collect(),
+                            self.defaults.iter().map(String::as_str).collect(),
                         ]
                         .concat(),
                         line,

--- a/crates/mipsy_interactive/src/interactive/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/mod.rs
@@ -629,12 +629,12 @@ impl State {
     }
 }
 
-pub(crate) fn editor() -> Editor<MyHelper> {
+pub(crate) fn editor(commands: &[Command]) -> Editor<MyHelper<'_>> {
     let mut rl = Editor::new().unwrap();
 
     rl.set_check_cursor_position(true);
 
-    let helper = MyHelper::new();
+    let helper = MyHelper::new(commands);
     rl.set_helper(Some(helper));
 
     rl.bind_sequence(
@@ -676,15 +676,9 @@ fn state(config: MipsyConfig) -> State {
 }
 
 pub fn launch(config: MipsyConfig) -> ! {
-    let mut rl = editor();
     let mut state = state(config);
-    rl.helper_mut().unwrap().set_defaults(
-        state
-            .commands
-            .iter()
-            .map(|c| c.names[0].to_owned())
-            .collect(),
-    );
+    let commands = state.commands.clone();
+    let mut rl = editor(&commands);
 
     let interrupted = state.interrupted.clone();
     ctrlc::set_handler(move || interrupted.store(true, Ordering::SeqCst))

--- a/crates/mipsy_interactive/src/interactive/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/mod.rs
@@ -84,7 +84,7 @@ impl State {
     fn find_command(&self, cmd: &str) -> Option<Command> {
         self.commands
             .iter()
-            .find(|command| command.name == cmd || command.aliases.iter().any(|alias| alias == cmd))
+            .find(|command| command.names.contains(&cmd.to_string()))
             .cloned()
     }
 
@@ -116,8 +116,8 @@ impl State {
             return self.handle_error(
                 CommandError::WithTip {
                     error: Box::new(CommandError::MissingArguments {
-                        args: required.to_vec(),
-                        instead: parts.to_vec(),
+                        args: required.iter().map(|a| a.name().to_owned()).collect(),
+                        instead: parts.clone(),
                     }),
                     tip: format!("try `{} {}`", "help".bold(), command_name.bold()),
                 },
@@ -653,21 +653,21 @@ fn state(config: MipsyConfig) -> State {
     let mut state = State::new(config);
 
     for command in [
-        commands::load_command(),
-        commands::run_command(),
-        commands::step_command(),
-        commands::reset_command(),
-        commands::watchpoint_command(),
-        commands::breakpoint_command(),
-        commands::disassemble_command(),
-        commands::context_command(),
-        commands::label_command(),
-        commands::labels_command(),
-        commands::examine_command(),
-        commands::print_command(),
-        commands::dot_command(),
-        commands::help_command(),
-        commands::exit_command(),
+        commands::load::command(),
+        commands::run::command(),
+        commands::step::command(),
+        commands::reset::command(),
+        commands::watchpoint::command(),
+        commands::breakpoint::command(),
+        commands::disassemble::command(),
+        commands::context::command(),
+        commands::label::command(),
+        commands::labels::command(),
+        commands::examine::command(),
+        commands::print::command(),
+        commands::dot::command(),
+        commands::help::command(),
+        commands::exit::command(),
     ] {
         state.add_command(command);
     }
@@ -678,9 +678,13 @@ fn state(config: MipsyConfig) -> State {
 pub fn launch(config: MipsyConfig) -> ! {
     let mut rl = editor();
     let mut state = state(config);
-    rl.helper_mut()
-        .unwrap()
-        .set_defaults(state.commands.iter().map(|c| c.name.to_owned()).collect());
+    rl.helper_mut().unwrap().set_defaults(
+        state
+            .commands
+            .iter()
+            .map(|c| c.names[0].to_owned())
+            .collect(),
+    );
 
     let interrupted = state.interrupted.clone();
     ctrlc::set_handler(move || interrupted.store(true, Ordering::SeqCst))

--- a/crates/mipsy_interactive/src/interactive/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/mod.rs
@@ -25,7 +25,7 @@ use mipsy_lib::{
 };
 
 use colored::*;
-use commands::{Arguments, Command};
+use commands::Command;
 use rustyline::{
     config::Configurer, error::ReadlineError, At, Cmd, Editor, KeyCode, KeyEvent, Modifiers,
     Movement, Word,
@@ -102,25 +102,7 @@ impl State {
             return prompt::unknown_command(command_name);
         };
 
-        let required = match &command.args {
-            Arguments::Exactly { required, .. } => required,
-            Arguments::VarArgs { required, .. } => required,
-        };
-
-        if (parts.len() - 1) < required.len() {
-            return self.handle_error(
-                CommandError::WithTip {
-                    error: Box::new(CommandError::MissingArguments {
-                        args: required.iter().map(|a| a.name().to_owned()).collect(),
-                        instead: parts.clone(),
-                    }),
-                    tip: format!("try `{} {}`", "help".bold(), command_name.bold()),
-                },
-                true,
-            );
-        }
-
-        if let Err(e) = command.exec(self, helper, command_name, &parts[1..]) {
+        if let Err(e) = command.exec(self, helper, &parts[1..]) {
             self.handle_error(e, true)
         }
     }

--- a/crates/mipsy_interactive/src/interactive/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/mod.rs
@@ -35,6 +35,7 @@ use mipsy_utils::MipsyConfig;
 
 use self::error::{CommandError, CommandResult};
 
+#[derive(Clone)]
 pub(crate) struct State {
     pub(crate) config: MipsyConfig,
     pub(crate) iset: InstSet,
@@ -88,7 +89,7 @@ impl State {
             .cloned()
     }
 
-    fn do_exec(&mut self, line: &str) {
+    fn do_exec(&mut self, line: &str, helper: &MyHelper) {
         let Some(parts) = shlex::split(line) else {
             return;
         };
@@ -102,14 +103,8 @@ impl State {
         };
 
         let required = match &command.args {
-            Arguments::Exactly {
-                required,
-                optional: _,
-            } => required,
-            Arguments::VarArgs {
-                required,
-                format: _,
-            } => required,
+            Arguments::Exactly { required, .. } => required,
+            Arguments::VarArgs { required, .. } => required,
         };
 
         if (parts.len() - 1) < required.len() {
@@ -125,7 +120,7 @@ impl State {
             );
         }
 
-        if let Err(e) = command.exec(self, command_name, &parts[1..]) {
+        if let Err(e) = command.exec(self, helper, command_name, &parts[1..]) {
             self.handle_error(e, true)
         }
     }
@@ -350,6 +345,7 @@ impl State {
         result: Result<SteppedRuntime, (Runtime, MipsyError)>,
         inst: u32,
         original_pc: u32,
+        helper: &MyHelper,
     ) -> CommandResult<bool> {
         let mut breakpoint = false;
         let mut trapped = false;
@@ -542,7 +538,7 @@ impl State {
                     runtime_handler::breakpoint(label.as_deref(), pc, &binary.line_numbers);
                     if let Some(bp) = bp {
                         bp.commands.clone().iter().for_each(|command| {
-                            self.exec_command(command.to_owned());
+                            self.exec_command(command.to_owned(), helper);
                         });
                     }
 
@@ -568,7 +564,7 @@ impl State {
                 // TODO(joshh): would be nice to have the watchpoint notification in between
                 // the actions for each watchpoint
                 to_exec.into_iter().for_each(|command| {
-                    self.exec_command(command);
+                    self.exec_command(command, helper);
                 });
 
                 if all_ignored {
@@ -582,27 +578,38 @@ impl State {
         })
     }
 
-    pub(crate) fn step(&mut self, verbose: bool) -> CommandResult<bool> {
+    pub(crate) fn step(&mut self, verbose: bool, helper: &MyHelper) -> CommandResult<bool> {
         let runtime = take(&mut self.runtime);
         let original_pc = runtime.timeline().state().pc();
         let inst = runtime.current_inst();
-        self.eval_stepped_runtime(verbose, runtime.step(), inst, original_pc)
+        self.eval_stepped_runtime(verbose, runtime.step(), inst, original_pc, helper)
     }
 
-    pub(crate) fn exec_inst(&mut self, opcode: u32, verbose: bool) -> CommandResult<bool> {
+    pub(crate) fn exec_inst(
+        &mut self,
+        opcode: u32,
+        verbose: bool,
+        helper: &MyHelper,
+    ) -> CommandResult<bool> {
         let runtime = take(&mut self.runtime);
         let original_pc = runtime.timeline().state().pc();
-        self.eval_stepped_runtime(verbose, runtime.exec_inst(opcode), opcode, original_pc)
+        self.eval_stepped_runtime(
+            verbose,
+            runtime.exec_inst(opcode),
+            opcode,
+            original_pc,
+            helper,
+        )
     }
 
-    pub(crate) fn run(&mut self) -> CommandResult<String> {
+    pub(crate) fn run(&mut self, helper: &MyHelper) -> CommandResult<String> {
         if self.exited {
             return Err(CommandError::ProgramExited);
         }
 
         self.interrupted.store(false, Ordering::SeqCst);
         while !self.interrupted.load(Ordering::SeqCst) {
-            if self.step(false)? {
+            if self.step(false, helper)? {
                 break;
             }
         }
@@ -617,24 +624,24 @@ impl State {
         Ok(())
     }
 
-    fn exec_command(&mut self, line: String) {
-        self.do_exec(&line);
+    fn exec_command(&mut self, line: String, helper: &MyHelper) {
+        self.do_exec(&line, helper);
         self.cleanup_cmd(line);
     }
 
-    fn exec_prev(&mut self) {
+    fn exec_prev(&mut self, helper: &MyHelper) {
         if let Some(cmd) = self.prev_command.take() {
-            self.exec_command(cmd);
+            self.exec_command(cmd, helper);
         }
     }
 }
 
-pub(crate) fn editor(commands: &[Command]) -> Editor<MyHelper<'_>> {
+pub(crate) fn editor(state: &State) -> Editor<MyHelper<'_>> {
     let mut rl = Editor::new().unwrap();
 
     rl.set_check_cursor_position(true);
 
-    let helper = MyHelper::new(commands);
+    let helper = MyHelper::new(state);
     rl.set_helper(Some(helper));
 
     rl.bind_sequence(
@@ -677,8 +684,8 @@ fn state(config: MipsyConfig) -> State {
 
 pub fn launch(config: MipsyConfig) -> ! {
     let mut state = state(config);
-    let commands = state.commands.clone();
-    let mut rl = editor(&commands);
+    let cs = state.clone();
+    let mut rl = editor(&cs);
 
     let interrupted = state.interrupted.clone();
     ctrlc::set_handler(move || interrupted.store(true, Ordering::SeqCst))
@@ -691,7 +698,7 @@ pub fn launch(config: MipsyConfig) -> ! {
             Ok(line) => {
                 if line.is_empty() {
                     if !state.confirm_exit {
-                        state.exec_prev();
+                        state.exec_prev(rl.helper().unwrap());
                     }
 
                     state.confirm_exit = false;
@@ -699,7 +706,7 @@ pub fn launch(config: MipsyConfig) -> ! {
                 }
 
                 rl.add_history_entry(&line);
-                state.exec_command(line);
+                state.exec_command(line, rl.helper().unwrap());
             }
             Err(ReadlineError::Interrupted) => {}
             Err(ReadlineError::Eof) => {

--- a/crates/mipsy_interactive/src/interactive/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/mod.rs
@@ -86,7 +86,7 @@ impl State {
                 err_msg.push_str(
                     &args[(instead.len().saturating_sub(1))..(args.len())]
                         .iter()
-                        .map(|s| format!("{}{}{}", "<".magenta(), s.magenta(), ">".magenta()))
+                        .map(|s| format!("<{s}>").magenta().to_string())
                         .collect::<Vec<String>>()
                         .join(" "),
                 );

--- a/crates/mipsy_interactive/src/interactive/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/mod.rs
@@ -44,7 +44,6 @@ pub(crate) struct State {
     pub(crate) binary: Option<Binary>,
     pub(crate) runtime: Runtime,
     pub(crate) exited: bool,
-    pub(crate) prev_command: Option<String>,
     pub(crate) interrupted: Arc<AtomicBool>,
 }
 
@@ -58,17 +57,12 @@ impl State {
             binary: None,
             runtime: Runtime::new_without_binary(),
             exited: false,
-            prev_command: None,
             interrupted: Arc::new(AtomicBool::new(false)),
         }
     }
 
     fn add_command(&mut self, command: Command) {
         self.commands.push(command);
-    }
-
-    fn cleanup_cmd(&mut self, cmd: String) {
-        self.prev_command = Some(cmd);
     }
 
     fn find_command(&self, cmd: &str) -> Option<Command> {
@@ -292,7 +286,7 @@ impl State {
         }
     }
 
-    fn do_exec(helper: &mut MyHelper, line: &str) {
+    fn exec_command(helper: &mut MyHelper, line: &str) {
         let Some(parts) = shlex::split(line) else {
             return;
         };
@@ -310,17 +304,6 @@ impl State {
 
         if let Err(e) = command.exec(helper, &parts[1..]) {
             helper.state.handle_error(e, true)
-        }
-    }
-
-    fn exec_command(helper: &mut MyHelper, line: String) {
-        Self::do_exec(helper, &line);
-        helper.state.cleanup_cmd(line);
-    }
-
-    fn exec_prev(helper: &mut MyHelper) {
-        if let Some(cmd) = helper.state.prev_command.take() {
-            Self::exec_command(helper, cmd);
         }
     }
 
@@ -522,7 +505,7 @@ impl State {
                     runtime_handler::breakpoint(label.as_deref(), pc, &binary.line_numbers);
                     if let Some(bp) = bp {
                         bp.commands.clone().iter().for_each(|command| {
-                            Self::exec_command(helper, command.to_owned());
+                            Self::exec_command(helper, command);
                         });
                     }
 
@@ -547,7 +530,7 @@ impl State {
 
                 // TODO(joshh): would be nice to have the watchpoint notification in between
                 // the actions for each watchpoint
-                to_exec.into_iter().for_each(|command| {
+                to_exec.iter().for_each(|command| {
                     Self::exec_command(helper, command);
                 });
 
@@ -665,7 +648,7 @@ pub fn launch(config: MipsyConfig) -> ! {
         match rl.readline("[mipsy] ") {
             Ok(line) => {
                 rl.add_history_entry(&line);
-                State::exec_command(rl.helper_mut().unwrap(), line);
+                State::exec_command(rl.helper_mut().unwrap(), &line);
             }
             Err(ReadlineError::Interrupted) => {}
             Err(ReadlineError::Eof) => {

--- a/crates/mipsy_interactive/src/interactive/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/mod.rs
@@ -45,7 +45,6 @@ pub(crate) struct State {
     pub(crate) runtime: Runtime,
     pub(crate) exited: bool,
     pub(crate) prev_command: Option<String>,
-    pub(crate) confirm_exit: bool,
     pub(crate) interrupted: Arc<AtomicBool>,
 }
 
@@ -60,7 +59,6 @@ impl State {
             runtime: Runtime::new_without_binary(),
             exited: false,
             prev_command: None,
-            confirm_exit: false,
             interrupted: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -69,16 +67,7 @@ impl State {
         self.commands.push(command);
     }
 
-    fn prompt(&self) -> &str {
-        if self.confirm_exit {
-            ""
-        } else {
-            "[mipsy] "
-        }
-    }
-
     fn cleanup_cmd(&mut self, cmd: String) {
-        self.confirm_exit = false;
         self.prev_command = Some(cmd);
     }
 
@@ -87,24 +76,6 @@ impl State {
             .iter()
             .find(|command| command.names.contains(&cmd.to_string()))
             .cloned()
-    }
-
-    fn do_exec(&mut self, line: &str, helper: &MyHelper) {
-        let Some(parts) = shlex::split(line) else {
-            return;
-        };
-
-        let Some(command_name) = parts.first() else {
-            return;
-        };
-
-        let Some(command) = self.find_command(&command_name.to_ascii_lowercase()) else {
-            return prompt::unknown_command(command_name);
-        };
-
-        if let Err(e) = command.exec(self, helper, &parts[1..]) {
-            self.handle_error(e, true)
-        }
     }
 
     fn handle_error(&self, err: CommandError, nl: bool) {
@@ -315,26 +286,57 @@ impl State {
                         .collect()
                 },
                 &self.iset,
-                self.binary.as_ref().unwrap(),
+                self.binary.as_ref().expect("no binary"),
                 &self.runtime,
             ),
         }
     }
 
+    fn do_exec(helper: &mut MyHelper, line: &str) {
+        let Some(parts) = shlex::split(line) else {
+            return;
+        };
+
+        let Some(command_name) = parts.first() else {
+            return;
+        };
+
+        let Some(command) = helper
+            .state
+            .find_command(&command_name.to_ascii_lowercase())
+        else {
+            return prompt::unknown_command(command_name);
+        };
+
+        if let Err(e) = command.exec(helper, &parts[1..]) {
+            helper.state.handle_error(e, true)
+        }
+    }
+
+    fn exec_command(helper: &mut MyHelper, line: String) {
+        Self::do_exec(helper, &line);
+        helper.state.cleanup_cmd(line);
+    }
+
+    fn exec_prev(helper: &mut MyHelper) {
+        if let Some(cmd) = helper.state.prev_command.take() {
+            Self::exec_command(helper, cmd);
+        }
+    }
+
     pub(crate) fn eval_stepped_runtime(
-        &mut self,
+        helper: &mut MyHelper,
         verbose: bool,
         result: Result<SteppedRuntime, (Runtime, MipsyError)>,
         inst: u32,
         original_pc: u32,
-        helper: &MyHelper,
     ) -> CommandResult<bool> {
         let mut breakpoint = false;
         let mut trapped = false;
 
         match result {
             Ok(Ok(new_runtime)) => {
-                self.runtime = new_runtime;
+                helper.state.runtime = new_runtime;
             }
             Ok(Err(guard)) => {
                 // Ok(true) on exit or breakpoint, see self::exec_status
@@ -342,61 +344,61 @@ impl State {
 
                 match guard {
                     PrintInt(args, new_runtime) => {
-                        self.runtime = new_runtime;
+                        helper.state.runtime = new_runtime;
                         runtime_handler::sys1_print_int(verbose, args.value);
                     }
                     PrintFloat(args, new_runtime) => {
-                        self.runtime = new_runtime;
+                        helper.state.runtime = new_runtime;
                         runtime_handler::sys2_print_float(verbose, args.value);
                     }
                     PrintDouble(args, new_runtime) => {
-                        self.runtime = new_runtime;
+                        helper.state.runtime = new_runtime;
                         runtime_handler::sys3_print_double(verbose, args.value);
                     }
                     PrintString(args, new_runtime) => {
-                        self.runtime = new_runtime;
+                        helper.state.runtime = new_runtime;
                         runtime_handler::sys4_print_string(verbose, &args.value);
                     }
                     ReadInt(guard) => {
                         let value = runtime_handler::sys5_read_int(verbose);
-                        self.runtime = guard(value);
+                        helper.state.runtime = guard(value);
                     }
                     ReadFloat(guard) => {
                         let value = runtime_handler::sys6_read_float(verbose);
-                        self.runtime = guard(value);
+                        helper.state.runtime = guard(value);
                     }
                     ReadDouble(guard) => {
                         let value = runtime_handler::sys7_read_double(verbose);
-                        self.runtime = guard(value);
+                        helper.state.runtime = guard(value);
                     }
                     ReadString(args, guard) => {
                         let value = runtime_handler::sys8_read_string(verbose, args.max_len);
-                        self.runtime = guard(value);
+                        helper.state.runtime = guard(value);
                     }
                     Sbrk(args, new_runtime) => {
-                        self.runtime = new_runtime;
+                        helper.state.runtime = new_runtime;
                         runtime_handler::sys9_sbrk(verbose, args.bytes);
                     }
                     Exit(new_runtime) => {
-                        self.runtime = new_runtime;
-                        self.exited = true;
+                        helper.state.runtime = new_runtime;
+                        helper.state.exited = true;
 
                         runtime_handler::sys10_exit(verbose);
                     }
                     PrintChar(args, new_runtime) => {
-                        self.runtime = new_runtime;
+                        helper.state.runtime = new_runtime;
                         runtime_handler::sys11_print_char(verbose, args.value);
                     }
                     ReadChar(guard) => {
                         let value = runtime_handler::sys12_read_char(verbose);
-                        self.runtime = guard(value);
+                        helper.state.runtime = guard(value);
                     }
                     Open(_args, guard) => {
                         // TODO: implement file open for mipsy interactive frontend
 
                         let mut new_runtime = guard(-1);
                         new_runtime.timeline_mut().pop_last_state();
-                        self.runtime = new_runtime;
+                        helper.state.runtime = new_runtime;
                         return Err(CommandError::RuntimeError {
                             mipsy_error: MipsyError::Runtime(RuntimeError::new(
                                 Error::InvalidSyscall {
@@ -407,14 +409,14 @@ impl State {
                         });
 
                         // let value = runtime_handler::sys13_open(verbose, args);
-                        // self.runtime = Some(guard(value));
+                        // helper.state.runtime = Some(guard(value));
                     }
                     Read(_args, guard) => {
                         // TODO: implement file read for mipsy interactive frontend
 
                         let mut new_runtime = guard((-1, Vec::new()));
                         new_runtime.timeline_mut().pop_last_state();
-                        self.runtime = new_runtime;
+                        helper.state.runtime = new_runtime;
                         return Err(CommandError::RuntimeError {
                             mipsy_error: MipsyError::Runtime(RuntimeError::new(
                                 Error::InvalidSyscall {
@@ -425,14 +427,14 @@ impl State {
                         });
 
                         // let value = runtime_handler::sys14_read(verbose, args);
-                        // self.runtime = Some(guard(value));
+                        // helper.state.runtime = Some(guard(value));
                     }
                     Write(_args, guard) => {
                         // TODO: implement file write for mipsy interactive frontend
 
                         let mut new_runtime = guard(-1);
                         new_runtime.timeline_mut().pop_last_state();
-                        self.runtime = new_runtime;
+                        helper.state.runtime = new_runtime;
                         return Err(CommandError::RuntimeError {
                             mipsy_error: MipsyError::Runtime(RuntimeError::new(
                                 Error::InvalidSyscall {
@@ -443,14 +445,14 @@ impl State {
                         });
 
                         // let value = runtime_handler::sys15_write(verbose, args);
-                        // self.runtime = Some(guard(value));
+                        // helper.state.runtime = Some(guard(value));
                     }
                     Close(_args, guard) => {
                         // TODO: implement file close for mipsy interactive frontend
 
                         let mut new_runtime = guard(-1);
                         new_runtime.timeline_mut().pop_last_state();
-                        self.runtime = new_runtime;
+                        helper.state.runtime = new_runtime;
                         return Err(CommandError::RuntimeError {
                             mipsy_error: MipsyError::Runtime(RuntimeError::new(
                                 Error::InvalidSyscall {
@@ -461,35 +463,35 @@ impl State {
                         });
 
                         // let value = runtime_handler::sys16_close(verbose, args);
-                        // self.runtime = Some(guard(value));
+                        // helper.state.runtime = Some(guard(value));
                     }
                     ExitStatus(args, new_runtime) => {
-                        self.runtime = new_runtime;
-                        self.exited = true;
+                        helper.state.runtime = new_runtime;
+                        helper.state.exited = true;
 
                         runtime_handler::sys17_exit_status(verbose, args.exit_code);
                     }
                     Breakpoint(new_runtime) => {
-                        self.runtime = new_runtime;
+                        helper.state.runtime = new_runtime;
                         breakpoint = true;
                     }
                     Trap(new_runtime) => {
-                        self.runtime = new_runtime;
+                        helper.state.runtime = new_runtime;
                         runtime_handler::trap(verbose);
                         trapped = true;
                     }
                 }
             }
             Err((new_runtime, err)) => {
-                self.runtime = new_runtime;
+                helper.state.runtime = new_runtime;
 
                 return Err(CommandError::RuntimeError { mipsy_error: err });
             }
         };
 
         let mut empty_binary = Binary::default();
-        let binary = self.binary.as_mut().unwrap_or(&mut empty_binary);
-        let affected_registers = get_affected_registers(&self.runtime, inst);
+        let binary = helper.state.binary.as_mut().unwrap_or(&mut empty_binary);
+        let affected_registers = get_affected_registers(&helper.state.runtime, inst);
         // TODO(joshh): move this into else if once let-chains are stabilised (1.64 baited me smh)
         let watchpoints = affected_registers
             .iter()
@@ -500,10 +502,10 @@ impl State {
             })
             .collect::<Vec<_>>();
 
-        Ok(if self.exited {
+        Ok(if helper.state.exited {
             true
         } else {
-            let pc = self.runtime.timeline().state().pc();
+            let pc = helper.state.runtime.timeline().state().pc();
             let bp = binary.breakpoints.get_mut(&pc);
 
             if breakpoint || (bp.is_some() && bp.as_ref().unwrap().enabled) {
@@ -520,7 +522,7 @@ impl State {
                     runtime_handler::breakpoint(label.as_deref(), pc, &binary.line_numbers);
                     if let Some(bp) = bp {
                         bp.commands.clone().iter().for_each(|command| {
-                            self.exec_command(command.to_owned(), helper);
+                            Self::exec_command(helper, command.to_owned());
                         });
                     }
 
@@ -546,7 +548,7 @@ impl State {
                 // TODO(joshh): would be nice to have the watchpoint notification in between
                 // the actions for each watchpoint
                 to_exec.into_iter().for_each(|command| {
-                    self.exec_command(command, helper);
+                    Self::exec_command(helper, command);
                 });
 
                 if all_ignored {
@@ -560,38 +562,37 @@ impl State {
         })
     }
 
-    pub(crate) fn step(&mut self, verbose: bool, helper: &MyHelper) -> CommandResult<bool> {
-        let runtime = take(&mut self.runtime);
+    pub(crate) fn step(helper: &mut MyHelper, verbose: bool) -> CommandResult<bool> {
+        let runtime = take(&mut helper.state.runtime);
         let original_pc = runtime.timeline().state().pc();
         let inst = runtime.current_inst();
-        self.eval_stepped_runtime(verbose, runtime.step(), inst, original_pc, helper)
+        Self::eval_stepped_runtime(helper, verbose, runtime.step(), inst, original_pc)
     }
 
     pub(crate) fn exec_inst(
-        &mut self,
+        helper: &mut MyHelper,
         opcode: u32,
         verbose: bool,
-        helper: &MyHelper,
     ) -> CommandResult<bool> {
-        let runtime = take(&mut self.runtime);
-        let original_pc = runtime.timeline().state().pc();
-        self.eval_stepped_runtime(
+        let runtime = take(&mut helper.state.runtime);
+        let original_pc = helper.state.runtime.timeline().state().pc();
+        Self::eval_stepped_runtime(
+            helper,
             verbose,
             runtime.exec_inst(opcode),
             opcode,
             original_pc,
-            helper,
         )
     }
 
-    pub(crate) fn run(&mut self, helper: &MyHelper) -> CommandResult<String> {
-        if self.exited {
+    pub(crate) fn run(helper: &mut MyHelper) -> CommandResult<String> {
+        if helper.state.exited {
             return Err(CommandError::ProgramExited);
         }
 
-        self.interrupted.store(false, Ordering::SeqCst);
-        while !self.interrupted.load(Ordering::SeqCst) {
-            if self.step(false, helper)? {
+        helper.state.interrupted.store(false, Ordering::SeqCst);
+        while !helper.state.interrupted.load(Ordering::SeqCst) {
+            if Self::step(helper, false)? {
                 break;
             }
         }
@@ -605,20 +606,9 @@ impl State {
 
         Ok(())
     }
-
-    fn exec_command(&mut self, line: String, helper: &MyHelper) {
-        self.do_exec(&line, helper);
-        self.cleanup_cmd(line);
-    }
-
-    fn exec_prev(&mut self, helper: &MyHelper) {
-        if let Some(cmd) = self.prev_command.take() {
-            self.exec_command(cmd, helper);
-        }
-    }
 }
 
-pub(crate) fn editor(state: &State) -> Editor<MyHelper<'_>> {
+pub(crate) fn editor(state: State) -> Editor<MyHelper> {
     let mut rl = Editor::new().unwrap();
 
     rl.set_check_cursor_position(true);
@@ -665,30 +655,17 @@ fn state(config: MipsyConfig) -> State {
 }
 
 pub fn launch(config: MipsyConfig) -> ! {
-    let mut state = state(config);
-    let cs = state.clone();
-    let mut rl = editor(&cs);
+    let mut rl = editor(state(config));
 
-    let interrupted = state.interrupted.clone();
+    let interrupted = rl.helper().unwrap().state.interrupted.clone();
     ctrlc::set_handler(move || interrupted.store(true, Ordering::SeqCst))
         .expect("Failed to set signal handler!");
 
     loop {
-        let readline = rl.readline(state.prompt());
-
-        match readline {
+        match rl.readline("[mipsy] ") {
             Ok(line) => {
-                if line.is_empty() {
-                    if !state.confirm_exit {
-                        state.exec_prev(rl.helper().unwrap());
-                    }
-
-                    state.confirm_exit = false;
-                    continue;
-                }
-
                 rl.add_history_entry(&line);
-                state.exec_command(line, rl.helper().unwrap());
+                State::exec_command(rl.helper_mut().unwrap(), line);
             }
             Err(ReadlineError::Interrupted) => {}
             Err(ReadlineError::Eof) => {

--- a/crates/mipsy_interactive/src/interactive/mod.rs
+++ b/crates/mipsy_interactive/src/interactive/mod.rs
@@ -89,24 +89,18 @@ impl State {
     }
 
     fn do_exec(&mut self, line: &str) {
-        let parts = match shlex::split(line) {
-            Some(parts) => parts,
-            None => return,
-        };
-
-        let command_name = match parts.first() {
-            Some(command_name) => command_name,
-            None => return,
-        };
-
-        let command = self.find_command(&command_name.to_ascii_lowercase());
-
-        if command.is_none() {
-            prompt::unknown_command(command_name);
+        let Some(parts) = shlex::split(line) else {
             return;
-        }
+        };
 
-        let command = command.unwrap();
+        let Some(command_name) = parts.first() else {
+            return;
+        };
+
+        let Some(command) = self.find_command(&command_name.to_ascii_lowercase()) else {
+            return prompt::unknown_command(command_name);
+        };
+
         let required = match &command.args {
             Arguments::Exactly {
                 required,
@@ -119,7 +113,7 @@ impl State {
         };
 
         if (parts.len() - 1) < required.len() {
-            self.handle_error(
+            return self.handle_error(
                 CommandError::WithTip {
                     error: Box::new(CommandError::MissingArguments {
                         args: required.to_vec(),
@@ -129,14 +123,11 @@ impl State {
                 },
                 true,
             );
-            return;
         }
 
-        let result = command.exec(self, command_name, &parts[1..]);
-        match result {
-            Ok(_) => {}
-            Err(err) => self.handle_error(err, true),
-        };
+        if let Err(e) = command.exec(self, command_name, &parts[1..]) {
+            self.handle_error(e, true)
+        }
     }
 
     fn handle_error(&self, err: CommandError, nl: bool) {
@@ -661,21 +652,25 @@ pub(crate) fn editor() -> Editor<MyHelper> {
 fn state(config: MipsyConfig) -> State {
     let mut state = State::new(config);
 
-    state.add_command(commands::load_command());
-    state.add_command(commands::run_command());
-    state.add_command(commands::step_command());
-    state.add_command(commands::reset_command());
-    state.add_command(commands::watchpoint_command());
-    state.add_command(commands::breakpoint_command());
-    state.add_command(commands::disassemble_command());
-    state.add_command(commands::context_command());
-    state.add_command(commands::label_command());
-    state.add_command(commands::labels_command());
-    state.add_command(commands::examine_command());
-    state.add_command(commands::print_command());
-    state.add_command(commands::dot_command());
-    state.add_command(commands::help_command());
-    state.add_command(commands::exit_command());
+    for command in [
+        commands::load_command(),
+        commands::run_command(),
+        commands::step_command(),
+        commands::reset_command(),
+        commands::watchpoint_command(),
+        commands::breakpoint_command(),
+        commands::disassemble_command(),
+        commands::context_command(),
+        commands::label_command(),
+        commands::labels_command(),
+        commands::examine_command(),
+        commands::print_command(),
+        commands::dot_command(),
+        commands::help_command(),
+        commands::exit_command(),
+    ] {
+        state.add_command(command);
+    }
 
     state
 }
@@ -683,6 +678,10 @@ fn state(config: MipsyConfig) -> State {
 pub fn launch(config: MipsyConfig) -> ! {
     let mut rl = editor();
     let mut state = state(config);
+    rl.helper_mut()
+        .unwrap()
+        .set_defaults(state.commands.iter().map(|c| c.name.to_owned()).collect());
+
     let interrupted = state.interrupted.clone();
     ctrlc::set_handler(move || interrupted.store(true, Ordering::SeqCst))
         .expect("Failed to set signal handler!");
@@ -706,7 +705,7 @@ pub fn launch(config: MipsyConfig) -> ! {
             }
             Err(ReadlineError::Interrupted) => {}
             Err(ReadlineError::Eof) => {
-                std::process::exit(0);
+                break;
             }
             Err(err) => {
                 println!("Error: {:?}", err);

--- a/crates/mipsy_lib/src/runtime/mod.rs
+++ b/crates/mipsy_lib/src/runtime/mod.rs
@@ -53,7 +53,7 @@ macro_rules! try_owned_self {
     };
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Runtime {
     timeline: Timeline,
 }

--- a/crates/mipsy_lib/src/runtime/state.rs
+++ b/crates/mipsy_lib/src/runtime/state.rs
@@ -17,7 +17,7 @@ pub const WRITE_MARKER_HI: u32 = 32;
 pub const TIMELINE_MAX_LEN: usize = 1_000_000;
 
 /// # A timeline of states
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Timeline {
     seed: State,
     timeline: VecDeque<State>,


### PR DESCRIPTION
- [X] hinting & tab completion for commands
- [X] hinting & tab completion for history
- [x] smart hinting & tab completion based on argument type 
- [x] let `State` be accessed in `Argument` callbacks for some extra specifc hinting
- [ ] recurse for default subcommand hinting
- [ ] fix old commands to use new api (with proper hinting and everything)
    - [ ] load
    - [x] run
    - [ ] step
    - [x] reset
    - [ ] watchpoint
    - [ ] breakpoint
    - [x] disassemble
    - [x] context
    - [x] label
    - [x] labels
    - [x] examine
    - [x] print
    - [x] dot
    - [ ] help
    - [x] exit

#### plus some other stuff
- a variety of bug fixes
- `Command` now uses the builder pattern
- `Argument` has more stuff onw:
```rust
pub(crate) struct Argument {
    name: String,                                                                // argument name e.g. File, Step count, Whatever
    sanitiser: fn(arg: &str, helper: &MyHelper) -> CommandResult<ArgumentKind>,  // given some context, is this argument valid
    hints: fn(harg: &HintArgs, helper: &MyHelper) -> Vec<String>,                // what hints are available for this argument? (used for prompt hints and completion)
}
```